### PR TITLE
Validate IR semantics for arithmetic and constructors

### DIFF
--- a/main.c
+++ b/main.c
@@ -4,6 +4,8 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <stdio.h>
+#include <stdarg.h>
 
 #define CKIT_IMPLEMENTATION
 #include "ckit.h"
@@ -299,6 +301,12 @@ typedef struct IR_Cmd
 TypeSystem g_types;
 SymbolTable g_symbols;
 IR_Cmd* g_ir;
+Type* g_type_void;
+Type* g_type_bool;
+Type* g_type_int;
+Type* g_type_uint;
+Type* g_type_float;
+Type* g_type_double;
 const char* current_decl_type_name;
 Type* current_decl_type_type;
 const char* current_param_type_name;
@@ -493,6 +501,729 @@ void type_system_free(TypeSystem* ts)
 	}
 }
 
+void type_system_cache_builtins(TypeSystem* ts)
+{
+	g_type_void = type_system_get(ts, sintern("void"));
+	g_type_bool = type_system_get(ts, sintern("bool"));
+	g_type_int = type_system_get(ts, sintern("int"));
+	g_type_uint = type_system_get(ts, sintern("uint"));
+	g_type_float = type_system_get(ts, sintern("float"));
+	g_type_double = type_system_get(ts, sintern("double"));
+	assert(g_type_void && g_type_bool && g_type_int && g_type_uint && g_type_float && g_type_double);
+}
+
+const char* type_display(const Type* type)
+{
+	if (!type) return "<unknown>";
+	if (type->name) return type->name;
+	return type_tag_name(type->tag);
+}
+
+TypeTag type_base_type(const Type* type)
+{
+	if (!type) return T_VOID;
+	switch (type->tag) {
+		case T_VEC:
+		case T_MAT:
+		case T_ARRAY:
+		return (TypeTag)type->base;
+		default:
+		return type->tag;
+	}
+}
+
+int type_is_scalar(const Type* type)
+{
+	if (!type) return 0;
+	if (type->tag == T_VEC || type->tag == T_MAT || type->tag == T_ARRAY) return 0;
+	return type->cols == 1 && type->rows == 1 && type->tag != T_VOID;
+}
+
+int type_is_vector(const Type* type)
+{
+	return type && type->tag == T_VEC;
+}
+
+int type_is_matrix(const Type* type)
+{
+	return type && type->tag == T_MAT;
+}
+
+int type_base_is_numeric(TypeTag tag)
+{
+	switch (tag) {
+		case T_INT:
+		case T_UINT:
+		case T_FLOAT:
+		case T_DOUBLE:
+		return 1;
+		default:
+		return 0;
+	}
+}
+
+int type_base_is_integer(TypeTag tag)
+{
+	return tag == T_INT || tag == T_UINT;
+}
+
+int type_is_numeric(const Type* type)
+{
+	return type_base_is_numeric(type_base_type(type));
+}
+
+int type_is_integer(const Type* type)
+{
+	return type_base_is_integer(type_base_type(type));
+}
+
+int type_is_bool_like(const Type* type)
+{
+	return type_base_type(type) == T_BOOL;
+}
+
+int type_equal(const Type* a, const Type* b)
+{
+	if (a == b) return 1;
+	if (!a || !b) return 0;
+	if (a->tag != b->tag) return 0;
+	if (a->cols != b->cols || a->rows != b->rows) return 0;
+	return type_base_type(a) == type_base_type(b);
+}
+
+int type_base_can_convert(TypeTag from, TypeTag to)
+{
+	if (from == to) return 1;
+	if (to == T_BOOL) return from == T_BOOL || type_base_is_numeric(from);
+	if (from == T_BOOL) return to == T_BOOL;
+	if (type_base_is_numeric(from) && type_base_is_numeric(to)) return 1;
+	return 0;
+}
+
+int type_scalar_can_convert(const Type* from, const Type* to)
+{
+	return type_base_can_convert(type_base_type(from), type_base_type(to));
+}
+
+const char* type_vector_name(TypeTag base, int cols)
+{
+	const char* prefix = NULL;
+	switch (base) {
+		case T_FLOAT: prefix = "vec"; break;
+		case T_INT: prefix = "ivec"; break;
+		case T_UINT: prefix = "uvec"; break;
+		case T_BOOL: prefix = "bvec"; break;
+		default: return NULL;
+	}
+	char buf[16];
+	int n = snprintf(buf, sizeof(buf), "%s%d", prefix, cols);
+	if (n <= 0 || n >= (int)sizeof(buf)) return NULL;
+	return sintern_range(buf, buf + n);
+}
+
+const char* type_matrix_name(TypeTag base, int cols, int rows)
+{
+	if (base != T_FLOAT && base != T_DOUBLE) return NULL;
+	char buf[16];
+	int n = 0;
+	if (cols == rows) {
+		n = snprintf(buf, sizeof(buf), "%s%d", base == T_FLOAT ? "mat" : "dmat", cols);
+	} else {
+	n = snprintf(buf, sizeof(buf), "%s%dx%d", base == T_FLOAT ? "mat" : "dmat", cols, rows);
+}
+if (n <= 0 || n >= (int)sizeof(buf)) return NULL;
+return sintern_range(buf, buf + n);
+}
+
+Type* type_get_scalar(TypeTag base)
+{
+	switch (base) {
+		case T_BOOL: return g_type_bool;
+		case T_INT: return g_type_int;
+		case T_UINT: return g_type_uint;
+		case T_FLOAT: return g_type_float;
+		case T_DOUBLE: return g_type_double;
+		default: return NULL;
+	}
+}
+
+Type* type_get_vector(TypeTag base, int cols)
+{
+	const char* name = type_vector_name(base, cols);
+	if (!name) return NULL;
+	return type_system_get(&g_types, name);
+}
+
+Type* type_get_matrix(TypeTag base, int cols, int rows)
+{
+	const char* name = type_matrix_name(base, cols, rows);
+	if (!name) return NULL;
+	return type_system_get(&g_types, name);
+}
+
+int type_can_assign(const Type* dst, const Type* src)
+{
+	if (!dst || !src) return 0;
+	if (type_equal(dst, src)) return 1;
+	if (type_is_scalar(dst) && type_is_scalar(src)) {
+		return type_scalar_can_convert(src, dst);
+	}
+	if (type_is_vector(dst) && type_is_vector(src)) {
+		if (dst->cols != src->cols) return 0;
+		if (type_base_type(dst) != type_base_type(src)) return 0;
+		return 1;
+	}
+	if (type_is_matrix(dst) && type_is_matrix(src)) {
+		if (dst->cols != src->cols || dst->rows != src->rows) return 0;
+		if (type_base_type(dst) != type_base_type(src)) return 0;
+		return 1;
+	}
+	return 0;
+}
+
+int type_component_count(const Type* type)
+{
+	if (!type) return 0;
+	if (type_is_scalar(type)) return 1;
+	if (type_is_vector(type)) return type->cols;
+	if (type_is_matrix(type)) return type->cols * type->rows;
+	return 0;
+}
+
+Type* type_bool_type(int components)
+{
+	if (components <= 1) return type_get_scalar(T_BOOL);
+	return type_get_vector(T_BOOL, components);
+}
+
+void type_check_error(const char* fmt, ...);
+
+Type* type_check_unary(Tok tok, Type* operand)
+{
+	if (!operand) return NULL;
+	switch (tok) {
+		case TOK_MINUS:
+		case TOK_PLUS:
+		if (!type_is_numeric(operand) && !type_is_matrix(operand)) {
+			type_check_error("operator %s requires numeric operand, got %s", tok_name[tok], type_display(operand));
+		}
+		return operand;
+		case TOK_NOT:
+		if (!type_is_bool_like(operand)) {
+			type_check_error("operator ! requires boolean operand, got %s", type_display(operand));
+		}
+		if (type_is_vector(operand)) {
+			return type_get_vector(T_BOOL, operand->cols);
+		}
+		return type_get_scalar(T_BOOL);
+		case TOK_TILDE:
+		if (!type_is_integer(operand)) {
+			type_check_error("operator %s requires integer operand, got %s", tok_name[tok], type_display(operand));
+		}
+		return operand;
+		default:
+		type_check_error("unsupported unary operator %s", tok_name[tok]);
+	}
+	return operand;
+}
+
+Type* type_binary_add_sub(Tok tok, Type* lhs, Type* rhs)
+{
+	if (!lhs || !rhs) return lhs ? lhs : rhs;
+	if (!type_is_numeric(lhs) || !type_is_numeric(rhs)) {
+		type_check_error("operator %s requires numeric operands, got %s and %s", tok_name[tok], type_display(lhs), type_display(rhs));
+	}
+	if (type_base_type(lhs) != type_base_type(rhs)) {
+		type_check_error("operator %s requires matching base types, got %s and %s", tok_name[tok], type_display(lhs), type_display(rhs));
+	}
+	if (type_is_scalar(lhs) && type_is_scalar(rhs)) return lhs;
+	if (type_is_scalar(lhs) && type_is_vector(rhs)) return rhs;
+	if (type_is_vector(lhs) && type_is_scalar(rhs)) return lhs;
+	if (type_is_vector(lhs) && type_is_vector(rhs)) {
+		if (lhs->cols != rhs->cols) {
+			type_check_error("operator %s requires matching vector sizes, got %d and %d", tok_name[tok], lhs->cols, rhs->cols);
+		}
+		return lhs;
+	}
+	if (type_is_matrix(lhs) && type_is_matrix(rhs)) {
+		if (lhs->cols != rhs->cols || lhs->rows != rhs->rows) {
+			type_check_error("operator %s requires matching matrix sizes", tok_name[tok]);
+		}
+		return lhs;
+	}
+	if (type_is_matrix(lhs) && type_is_scalar(rhs)) return lhs;
+	if (type_is_scalar(lhs) && type_is_matrix(rhs)) return rhs;
+	type_check_error("operator %s unsupported for %s and %s", tok_name[tok], type_display(lhs), type_display(rhs));
+	return NULL;
+}
+
+Type* type_binary_mul(Type* lhs, Type* rhs)
+{
+	if (!lhs || !rhs) return lhs ? lhs : rhs;
+	if (!type_is_numeric(lhs) || !type_is_numeric(rhs)) {
+		type_check_error("operator * requires numeric operands, got %s and %s", type_display(lhs), type_display(rhs));
+	}
+	if (type_base_type(lhs) != type_base_type(rhs)) {
+		type_check_error("operator * requires matching base types, got %s and %s", type_display(lhs), type_display(rhs));
+	}
+	if (type_is_scalar(lhs) && type_is_scalar(rhs)) return lhs;
+	if (type_is_scalar(lhs) && (type_is_vector(rhs) || type_is_matrix(rhs))) return rhs;
+	if (type_is_scalar(rhs) && (type_is_vector(lhs) || type_is_matrix(lhs))) return lhs;
+	if (type_is_vector(lhs) && type_is_vector(rhs)) {
+		if (lhs->cols != rhs->cols) {
+			type_check_error("operator * requires matching vector sizes, got %d and %d", lhs->cols, rhs->cols);
+		}
+		return lhs;
+	}
+	if (type_is_matrix(lhs) && type_is_matrix(rhs)) {
+		if (lhs->cols != rhs->cols || lhs->rows != rhs->rows) {
+			type_check_error("matrix multiplication currently requires matching dimensions");
+		}
+		return lhs;
+	}
+	type_check_error("operator * unsupported for %s and %s", type_display(lhs), type_display(rhs));
+	return NULL;
+}
+
+Type* type_binary_div(Type* lhs, Type* rhs)
+{
+	if (!lhs || !rhs) return lhs ? lhs : rhs;
+	if (!type_is_numeric(lhs) || !type_is_numeric(rhs)) {
+		type_check_error("operator / requires numeric operands, got %s and %s", type_display(lhs), type_display(rhs));
+	}
+	if (type_base_type(lhs) != type_base_type(rhs)) {
+		type_check_error("operator / requires matching base types, got %s and %s", type_display(lhs), type_display(rhs));
+	}
+	if (type_is_scalar(lhs) && type_is_scalar(rhs)) return lhs;
+	if (type_is_vector(lhs) && type_is_scalar(rhs)) return lhs;
+	if (type_is_scalar(lhs) && type_is_vector(rhs)) return rhs;
+	if (type_is_matrix(lhs) && type_is_scalar(rhs)) return lhs;
+	if (type_is_scalar(lhs) && type_is_matrix(rhs)) return rhs;
+	if (type_is_vector(lhs) && type_is_vector(rhs)) {
+		if (lhs->cols != rhs->cols) {
+			type_check_error("operator / requires matching vector sizes, got %d and %d", lhs->cols, rhs->cols);
+		}
+		return lhs;
+	}
+	type_check_error("operator / unsupported for %s and %s", type_display(lhs), type_display(rhs));
+	return NULL;
+}
+
+Type* type_binary_mod(Type* lhs, Type* rhs)
+{
+	if (!lhs || !rhs) return lhs ? lhs : rhs;
+	if (!type_is_integer(lhs) || !type_is_integer(rhs)) {
+		type_check_error("operator % requires integer operands, got %s and %s", type_display(lhs), type_display(rhs));
+	}
+	if (type_is_scalar(lhs) && type_is_scalar(rhs)) return lhs;
+	if (type_is_vector(lhs) && type_is_vector(rhs)) {
+		if (lhs->cols != rhs->cols) {
+			type_check_error("operator % requires matching vector sizes, got %d and %d", lhs->cols, rhs->cols);
+		}
+		return lhs;
+	}
+	if (type_is_vector(lhs) && type_is_scalar(rhs)) return lhs;
+	if (type_is_scalar(lhs) && type_is_vector(rhs)) return rhs;
+	type_check_error("operator % unsupported for %s and %s", type_display(lhs), type_display(rhs));
+	return NULL;
+}
+
+Type* type_binary_rel(Tok tok, Type* lhs, Type* rhs)
+{
+	if (!lhs || !rhs) return type_get_scalar(T_BOOL);
+	if (!type_is_numeric(lhs) || !type_is_numeric(rhs)) {
+		type_check_error("operator %s requires numeric operands, got %s and %s", tok_name[tok], type_display(lhs), type_display(rhs));
+	}
+	if (!type_is_scalar(lhs) || !type_is_scalar(rhs)) {
+		type_check_error("operator %s currently supports scalar operands only", tok_name[tok]);
+	}
+	if (type_base_type(lhs) != type_base_type(rhs)) {
+		type_check_error("operator %s requires matching base types", tok_name[tok]);
+	}
+	return type_get_scalar(T_BOOL);
+}
+
+Type* type_binary_eq(Tok tok, Type* lhs, Type* rhs)
+{
+	if (!lhs || !rhs) return type_get_scalar(T_BOOL);
+	if (type_is_vector(lhs) && type_is_vector(rhs)) {
+		if (lhs->cols != rhs->cols || type_base_type(lhs) != type_base_type(rhs)) {
+			type_check_error("operator %s requires matching vector types", tok_name[tok]);
+		}
+		return type_get_vector(T_BOOL, lhs->cols);
+	}
+	if (type_is_scalar(lhs) && type_is_scalar(rhs)) {
+		if (type_base_type(lhs) != type_base_type(rhs)) {
+			type_check_error("operator %s requires matching scalar types", tok_name[tok]);
+		}
+		return type_get_scalar(T_BOOL);
+	}
+	type_check_error("operator %s unsupported for %s and %s", tok_name[tok], type_display(lhs), type_display(rhs));
+	return type_get_scalar(T_BOOL);
+}
+
+Type* type_binary_logical(Tok tok, Type* lhs, Type* rhs)
+{
+	if (!lhs || !rhs) return type_get_scalar(T_BOOL);
+	if (!type_is_bool_like(lhs) || !type_is_bool_like(rhs) || !type_is_scalar(lhs) || !type_is_scalar(rhs)) {
+		type_check_error("operator %s requires boolean scalars", tok_name[tok]);
+	}
+	return type_get_scalar(T_BOOL);
+}
+
+Type* type_binary_assign(Type* lhs, Type* rhs)
+{
+	if (!lhs) return rhs;
+	if (!rhs) return lhs;
+	if (!type_can_assign(lhs, rhs)) {
+		type_check_error("cannot assign value of type %s to %s", type_display(rhs), type_display(lhs));
+	}
+	return lhs;
+}
+
+Type* type_check_binary(Tok tok, Type* lhs, Type* rhs)
+{
+	switch (tok) {
+		case TOK_PLUS:
+		case TOK_MINUS:
+		return type_binary_add_sub(tok, lhs, rhs);
+		case TOK_STAR:
+		return type_binary_mul(lhs, rhs);
+		case TOK_SLASH:
+		return type_binary_div(lhs, rhs);
+		case TOK_PERCENT:
+		return type_binary_mod(lhs, rhs);
+		case TOK_LT:
+		case TOK_LE:
+		case TOK_GT:
+		case TOK_GE:
+		return type_binary_rel(tok, lhs, rhs);
+		case TOK_EQ:
+		case TOK_NE:
+		return type_binary_eq(tok, lhs, rhs);
+		case TOK_AND_AND:
+		case TOK_OR_OR:
+		return type_binary_logical(tok, lhs, rhs);
+		case TOK_ASSIGN:
+		return type_binary_assign(lhs, rhs);
+		default:
+		type_check_error("unsupported binary operator %s", tok_name[tok]);
+	}
+	return NULL;
+}
+
+Type* type_select_result(Type* cond, Type* true_type, Type* false_type)
+{
+	if (cond && (!type_is_bool_like(cond) || !type_is_scalar(cond))) {
+		type_check_error("ternary condition must be boolean scalar, got %s", type_display(cond));
+	}
+	if (!true_type || !false_type) return true_type ? true_type : false_type;
+	if (!type_equal(true_type, false_type)) {
+		type_check_error("ternary branches must match types, got %s and %s", type_display(true_type), type_display(false_type));
+	}
+	return true_type;
+}
+
+void type_check_constructor(Type* target, Type** args, int argc)
+{
+	if (!target) return;
+	int has_unknown = 0;
+	for (int i = 0; i < argc; ++i) {
+		if (!args[i]) {
+			has_unknown = 1;
+			break;
+		}
+	}
+	if (has_unknown) return;
+	TypeTag base = type_base_type(target);
+	switch (target->tag) {
+		case T_VEC: {
+			int needed = target->cols;
+			int count = 0;
+			for (int i = 0; i < argc; ++i) {
+				Type* arg = args[i];
+				if (!type_base_can_convert(type_base_type(arg), base)) {
+					type_check_error("cannot pass %s to constructor %s", type_display(arg), type_display(target));
+				}
+				if (type_is_scalar(arg)) count += 1;
+				else if (type_is_vector(arg)) count += arg->cols;
+				else type_check_error("vector constructor arguments must be scalar or vector, got %s", type_display(arg));
+			}
+			if (count != needed) {
+				type_check_error("constructor %s expected %d components but received %d", type_display(target), needed, count);
+			}
+			break;
+		}
+		case T_MAT: {
+			int needed = target->cols * target->rows;
+			int count = 0;
+			for (int i = 0; i < argc; ++i) {
+				Type* arg = args[i];
+				if (!type_base_can_convert(type_base_type(arg), base)) {
+					type_check_error("cannot pass %s to constructor %s", type_display(arg), type_display(target));
+				}
+				if (type_is_scalar(arg)) {
+					count += 1;
+				} else if (type_is_vector(arg)) {
+				if (arg->cols != target->rows) {
+					type_check_error("matrix constructor column argument expected %d components, got %d", target->rows, arg->cols);
+				}
+				count += arg->cols;
+			} else {
+			type_check_error("matrix constructor arguments must be scalars or column vectors, got %s", type_display(arg));
+		}
+	}
+	if (count != needed) {
+		type_check_error("constructor %s expected %d components but received %d", type_display(target), needed, count);
+	}
+	break;
+}
+default:
+if (!type_is_scalar(target)) {
+	type_check_error("unsupported constructor target %s", type_display(target));
+}
+if (argc != 1) {
+	type_check_error("scalar constructor %s expects 1 argument, got %d", type_display(target), argc);
+}
+if (!type_scalar_can_convert(args[0], target)) {
+	type_check_error("cannot convert %s to %s", type_display(args[0]), type_display(target));
+}
+break;
+}
+}
+
+void type_check_error(const char* fmt, ...)
+{
+	va_list args;
+	va_start(args, fmt);
+	fprintf(stderr, "Type error: ");
+	vfprintf(stderr, fmt, args);
+	fprintf(stderr, "\n");
+	va_end(args);
+	exit(1);
+}
+
+Type* type_stack_pop(Type*** stack, const char* context)
+{
+	if (!*stack || acount(*stack) == 0) {
+		type_check_error("missing operand for %s", context);
+	}
+	return apop(*stack);
+}
+
+void type_stack_push(Type*** stack, Type* type)
+{
+	apush(*stack, type);
+}
+
+void type_check_ir()
+{
+	Type** stack = NULL;
+	Type** func_stack = NULL;
+	Type* current_decl_type = NULL;
+	for (int i = 0; i < acount(g_ir); ++i) {
+		IR_Cmd* inst = &g_ir[i];
+		switch (inst->op) {
+		case IR_PUSH_INT:
+			inst->type = g_type_int;
+			type_stack_push(&stack, inst->type);
+			break;
+		case IR_PUSH_FLOAT:
+			inst->type = g_type_float;
+			type_stack_push(&stack, inst->type);
+			break;
+		case IR_PUSH_IDENT: {
+			Type* type = NULL;
+			if (inst->str0) {
+				Symbol* sym = symbol_table_resolve(&g_symbols, inst->str0);
+				if (sym && sym->type) {
+					type = sym->type;
+				} else {
+					type = type_system_get(&g_types, inst->str0);
+				}
+			}
+			inst->type = type;
+			type_stack_push(&stack, type);
+			break;
+		}
+		case IR_UNARY: {
+			Type* operand = type_stack_pop(&stack, "unary expression");
+			Type* result = type_check_unary(inst->tok, operand);
+			if (!result) result = operand;
+			inst->type = result;
+			type_stack_push(&stack, result);
+			break;
+		}
+		case IR_BINARY: {
+			Type* rhs = type_stack_pop(&stack, "binary rhs");
+			Type* lhs = type_stack_pop(&stack, "binary lhs");
+			Type* result = type_check_binary(inst->tok, lhs, rhs);
+			if (!result) result = lhs ? lhs : rhs;
+			inst->type = result;
+			type_stack_push(&stack, result);
+			break;
+		}
+		case IR_CALL: {
+			Type** args = NULL;
+			for (int arg = 0; arg < inst->arg0; ++arg) {
+				Type* arg_type = type_stack_pop(&stack, "call argument");
+				apush(args, arg_type);
+			}
+			int argc = acount(args);
+			for (int l = 0, r = argc - 1; l < r; ++l, --r) {
+				Type* tmp = args[l];
+				args[l] = args[r];
+				args[r] = tmp;
+			}
+			Type* callee = type_stack_pop(&stack, "call target");
+			inst->type = callee;
+			if (args) afree(args);
+			type_stack_push(&stack, callee);
+			break;
+		}
+		case IR_CONSTRUCT: {
+			Type** args = NULL;
+			for (int arg = 0; arg < inst->arg0; ++arg) {
+				Type* arg_type = type_stack_pop(&stack, "constructor argument");
+				apush(args, arg_type);
+			}
+			int argc = acount(args);
+			for (int l = 0, r = argc - 1; l < r; ++l, --r) {
+				Type* tmp = args[l];
+				args[l] = args[r];
+				args[r] = tmp;
+			}
+			Type* target = type_stack_pop(&stack, "constructor target");
+			Type* result = inst->type ? inst->type : target;
+			inst->type = result;
+			if (result) type_check_constructor(result, args, argc);
+			if (args) afree(args);
+			type_stack_push(&stack, result);
+			break;
+		}
+		case IR_INDEX: {
+			Type* index = type_stack_pop(&stack, "index expression");
+			Type* base = type_stack_pop(&stack, "index base");
+			if (index && (!type_is_scalar(index) || !type_is_integer(index))) {
+				type_check_error("index expression must be integer scalar, got %s", type_display(index));
+			}
+			Type* result = NULL;
+			if (base) {
+				if (type_is_vector(base)) {
+					result = type_get_scalar(type_base_type(base));
+				} else if (type_is_matrix(base)) {
+					result = type_get_vector(type_base_type(base), base->rows);
+				} else {
+					type_check_error("type %s is not indexable", type_display(base));
+				}
+			}
+			inst->type = result;
+			type_stack_push(&stack, result);
+			break;
+		}
+		case IR_SWIZZLE: {
+			Type* base = type_stack_pop(&stack, "swizzle base");
+			if (base && !type_is_vector(base)) {
+				type_check_error("cannot swizzle non-vector type %s", type_display(base));
+			}
+			Type* result = NULL;
+			if (base) {
+				if (inst->arg0 == 1) {
+					result = type_get_scalar(type_base_type(base));
+				} else {
+					result = type_get_vector(type_base_type(base), inst->arg0);
+				}
+			}
+			if (!result) {
+				type_check_error("unsupported swizzle size %d on %s", inst->arg0, type_display(base));
+			}
+			inst->type = result;
+			type_stack_push(&stack, result);
+			break;
+		}
+		case IR_MEMBER: {
+			Type* base = type_stack_pop(&stack, "member access");
+			inst->type = base;
+			type_stack_push(&stack, base);
+			break;
+		}
+		case IR_SELECT: {
+			Type* false_type = type_stack_pop(&stack, "ternary false branch");
+			Type* true_type = type_stack_pop(&stack, "ternary true branch");
+			Type* cond_type = type_stack_pop(&stack, "ternary condition");
+			Type* result = type_select_result(cond_type, true_type, false_type);
+			if (!result) result = true_type ? true_type : false_type;
+			inst->type = result;
+			type_stack_push(&stack, result);
+			break;
+		}
+		case IR_DECL_TYPE:
+			current_decl_type = type_system_get(&g_types, inst->str0);
+			inst->type = current_decl_type;
+			break;
+		case IR_DECL_END:
+			current_decl_type = NULL;
+			break;
+		case IR_DECL_INIT_END:
+			if (acount(stack) > 0) {
+				Type* value = type_stack_pop(&stack, "initializer");
+				if (current_decl_type && value && !type_can_assign(current_decl_type, value)) {
+					type_check_error("initializer type %s cannot initialize %s", type_display(value), type_display(current_decl_type));
+				}
+			}
+			if (acount(stack) > 0) aclear(stack);
+			break;
+		case IR_DECL_ARRAY_SIZE_END:
+		case IR_FUNC_PARAM_ARRAY_SIZE_END:
+			if (acount(stack) > 0) {
+				Type* size = type_stack_pop(&stack, "array size");
+				if (size && (!type_is_scalar(size) || !type_is_integer(size))) {
+					type_check_error("array size must be integer scalar, got %s", type_display(size));
+				}
+			}
+			if (acount(stack) > 0) aclear(stack);
+			break;
+		case IR_STMT_EXPR:
+			if (acount(stack) > 0) type_stack_pop(&stack, "expression result");
+			if (acount(stack) > 0) aclear(stack);
+			break;
+		case IR_IF_THEN: {
+			Type* cond = type_stack_pop(&stack, "if condition");
+			if (cond && (!type_is_bool_like(cond) || !type_is_scalar(cond))) {
+				type_check_error("if condition must be boolean scalar, got %s", type_display(cond));
+			}
+			break;
+		}
+		case IR_RETURN: {
+			Type* ret_type = acount(func_stack) ? func_stack[acount(func_stack) - 1] : NULL;
+			if (inst->arg0) {
+				Type* value = type_stack_pop(&stack, "return value");
+				if (ret_type && ret_type != g_type_void && value && !type_can_assign(ret_type, value)) {
+					type_check_error("return type mismatch: expected %s got %s", type_display(ret_type), type_display(value));
+				}
+			} else if (ret_type && ret_type != g_type_void) {
+				type_check_error("return statement missing value for function returning %s", type_display(ret_type));
+			}
+			break;
+		}
+		case IR_FUNC_BEGIN: {
+			Type* ret = type_system_get(&g_types, inst->str0);
+			inst->type = ret;
+			apush(func_stack, ret);
+			break;
+		}
+		case IR_FUNC_PROTOTYPE_END:
+		case IR_FUNC_DEFINITION_END:
+			if (acount(func_stack) > 0) apop(func_stack);
+			break;
+		default:
+			break;
+		}
+	}
+	if (stack) afree(stack);
+	if (func_stack) afree(func_stack);
+}
+
 void symbol_add_storage(Symbol* sym, unsigned flags)
 {
 	sym->storage_flags |= flags;
@@ -646,7 +1377,7 @@ void dump_ir()
 		case IR_CONTINUE:
 		case IR_DISCARD:
 			break;
-		default:
+	default:
 			break;
 		}
 		printf("\n");
@@ -732,17 +1463,17 @@ void skip_ws_comments()
 		while (is_space(ch)) next_ch();
 		if (ch == '/' && at[0] == '/') {
 			while (ch && ch != '\n') {
-				next_ch();
+	next_ch();
 			}
 			continue;
 		}
 		if (ch == '/' && at[0] == '*') {
-			next_ch();
-			next_ch();
+	next_ch();
+	next_ch();
 			while (ch && !(ch == '*' && at[0] == '/')) next_ch();
 			if (ch == '*') {
-				next_ch();
-				next_ch();
+	next_ch();
+	next_ch();
 			}
 			continue;
 		}
@@ -812,13 +1543,13 @@ void parse_layout_block(TypeSpec* spec)
 		if (tok.kind != TOK_IDENTIFIER) parse_error("expected identifier in layout");
 		unsigned layout_flag = layout_flag_from_keyword(tok.lexeme);
 		if (!layout_flag) parse_error("unknown layout identifier");
-		next();
+	next();
 		expect(TOK_ASSIGN);
 		if (tok.kind != TOK_INT) parse_error("expected integer in layout assignment");
 		type_spec_set_layout(spec, layout_flag, tok.int_val);
-		next();
+	next();
 		if (tok.kind == TOK_COMMA) {
-			next();
+	next();
 			continue;
 		}
 		break;
@@ -832,7 +1563,7 @@ void parse_type_qualifiers(TypeSpec* spec)
 		unsigned storage_flag = storage_flag_from_keyword(tok.lexeme);
 		if (storage_flag) {
 			type_spec_add_storage(spec, storage_flag);
-			next();
+	next();
 			continue;
 		}
 		if (tok.lexeme == kw_layout) {
@@ -887,7 +1618,7 @@ void parse();
 void decl_array_suffix()
 {
 	while (tok.kind == TOK_LBRACK) {
-		next();
+	next();
 		ir_emit(IR_DECL_ARRAY_BEGIN);
 		if (tok.kind == TOK_RBRACK) {
 			ir_emit(IR_DECL_ARRAY_UNSIZED);
@@ -904,7 +1635,7 @@ void decl_array_suffix()
 void func_param_array_suffix()
 {
 	while (tok.kind == TOK_LBRACK) {
-		next();
+	next();
 		ir_emit(IR_FUNC_PARAM_ARRAY_BEGIN);
 		if (tok.kind == TOK_RBRACK) {
 			ir_emit(IR_FUNC_PARAM_ARRAY_UNSIZED);
@@ -946,7 +1677,7 @@ void func_param_list()
 		while (1) {
 			func_param();
 			if (tok.kind == TOK_COMMA) {
-				next();
+	next();
 				ir_emit(IR_FUNC_PARAM_SEPARATOR);
 				continue;
 			}
@@ -967,13 +1698,13 @@ void global_var_decl(TypeSpec spec, const char* first_name)
 	symbol_apply_type_spec(sym, &spec);
 	decl_array_suffix();
 	if (tok.kind == TOK_ASSIGN) {
-		next();
+	next();
 		ir_emit(IR_DECL_INIT_BEGIN);
 		expr();
 		ir_emit(IR_DECL_INIT_END);
 	}
 	while (tok.kind == TOK_COMMA) {
-		next();
+	next();
 		ir_emit(IR_DECL_SEPARATOR);
 		if (tok.kind != TOK_IDENTIFIER) parse_error("expected identifier in declaration");
 		const char* name = sintern_range(tok.lexeme, tok.lexeme + tok.len);
@@ -981,10 +1712,10 @@ void global_var_decl(TypeSpec spec, const char* first_name)
 		inst->str0 = name;
 		sym = symbol_table_add(&g_symbols, name, current_decl_type_name, current_decl_type_type, SYM_VAR);
 		symbol_apply_type_spec(sym, &spec);
-		next();
+	next();
 		decl_array_suffix();
 		if (tok.kind == TOK_ASSIGN) {
-			next();
+	next();
 			ir_emit(IR_DECL_INIT_BEGIN);
 			expr();
 			ir_emit(IR_DECL_INIT_END);
@@ -1008,7 +1739,7 @@ void func_decl_or_def(TypeSpec spec, const char* name)
 	symbol_table_enter_scope(&g_symbols);
 	func_param_list();
 	if (tok.kind == TOK_SEMI) {
-		next();
+	next();
 		symbol_table_leave_scope(&g_symbols);
 		ir_emit(IR_FUNC_PROTOTYPE_END);
 		return;
@@ -1036,16 +1767,16 @@ void stmt_decl()
 		inst->str0 = name;
 		Symbol* sym = symbol_table_add(&g_symbols, name, current_decl_type_name, current_decl_type_type, SYM_VAR);
 		symbol_apply_type_spec(sym, &spec);
-		next();
+	next();
 		decl_array_suffix();
 		if (tok.kind == TOK_ASSIGN) {
-			next();
+	next();
 			ir_emit(IR_DECL_INIT_BEGIN);
 			expr();
 			ir_emit(IR_DECL_INIT_END);
 		}
 		if (tok.kind == TOK_COMMA) {
-			next();
+	next();
 			ir_emit(IR_DECL_SEPARATOR);
 			continue;
 		}
@@ -1093,7 +1824,7 @@ void expr_call()
 		expr();
 		argc++;
 		while (tok.kind == TOK_COMMA) {
-			next();
+	next();
 			expr();
 			argc++;
 		}
@@ -1274,7 +2005,7 @@ void stmt_if()
 	ir_emit(IR_IF_THEN);
 	stmt();
 	if (tok.kind == TOK_ELSE) {
-		next();
+	next();
 		ir_emit(IR_IF_ELSE);
 		stmt();
 	}
@@ -1347,7 +2078,7 @@ void stmt()
 		stmt_discard();
 		break;
 	case TOK_SEMI:
-		next();
+	next();
 		break;
 	case TOK_EOF:
 		break;
@@ -1542,8 +2273,8 @@ void next()
 	// unknown char: consume and retry
 	if (ch) {
 		fprintf(stderr, "Unknown char: '%c'\n", ch);
-		next_ch();
-		next();
+	next_ch();
+	next();
 		return;
 	}
 }
@@ -1619,10 +2350,12 @@ void unit_test()
 	at = in;
 	g_ir = NULL;
 	type_system_init_builtins(&g_types);
+	type_system_cache_builtins(&g_types);
 	symbol_table_init(&g_symbols);
 	next_ch();
 	next();
 	parse();
+	type_check_ir();
 	assert(acount(g_ir) > 0);
 	assert(acount(g_symbols.symbols) > 0);
 	symbol_table_free(&g_symbols);
@@ -1708,13 +2441,15 @@ int main()
 
 	in = input;
 	at = in;
-	init_keyword_interns();
+init_keyword_interns();
 	next_ch();
 	next();
 	type_system_init_builtins(&g_types);
+	type_system_cache_builtins(&g_types);
 	symbol_table_init(&g_symbols);
 	parse();
-	dump_ir();
+	type_check_ir();
+dump_ir();
 	printf("\n");
 	dump_symbols(&g_symbols);
 	symbol_table_free(&g_symbols);


### PR DESCRIPTION
## Summary
- rewrite `type_check_ir` to drive type validation through the new helper routines
- ensure constructor, arithmetic, indexing, swizzle, declaration, and return IR nodes enforce GLSL type rules

## Testing
- gcc -std=c11 -Wall -Wextra -pedantic -c main.c

------
https://chatgpt.com/codex/tasks/task_e_68e0b65e68648323a9e183ee9b054e31