### PR TITLE
Ensure IR marks if branches with block delimiters

### DIFF
--- a/main.c
+++ b/main.c
@@ -1613,6 +1613,7 @@ void expr_error() { parse_error("unexpected token in expression"); }
 void stmt();
 void stmt_decl();
 void stmt_block();
+void stmt_controlled();
 void parse();
 
 void decl_array_suffix()
@@ -1995,6 +1996,17 @@ void stmt_block()
 	ir_emit(IR_BLOCK_END);
 }
 
+void stmt_controlled()
+{
+	if (tok.kind == TOK_LBRACE) {
+		stmt_block();
+		return;
+	}
+	ir_emit(IR_BLOCK_BEGIN);
+	stmt();
+	ir_emit(IR_BLOCK_END);
+}
+
 void stmt_if()
 {
 	expect(TOK_IF);
@@ -2003,11 +2015,11 @@ void stmt_if()
 	expr();
 	expect(TOK_RPAREN);
 	ir_emit(IR_IF_THEN);
-	stmt();
+	stmt_controlled();
 	if (tok.kind == TOK_ELSE) {
-	next();
+		next();
 		ir_emit(IR_IF_ELSE);
-		stmt();
+		stmt_controlled();
 	}
 	ir_emit(IR_IF_END);
 }


### PR DESCRIPTION
## Summary
- add a stmt_controlled helper that wraps single-statement control-flow bodies in IR block markers
- emit stmt_controlled for both the then and else portions of an if statement so IR consumers can delineate branch bodies

## Testing
- gcc -std=c11 -Wall -Wextra -Werror main.c *(fails: warnings in ckit.h promoted to errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e0bdd8bdcc8323a45c19a537b3bcf5