### PR TITLE
Add snippet coverage and transpile helper

### DIFF
--- a/GLSL450_FEATURE_GAPS.md
+++ b/GLSL450_FEATURE_GAPS.md
@@ -1,0 +1,11 @@
+# GLSL 450 Feature Gaps
+
+The current front end focuses on a narrow subset of GLSL 450. The following areas still need implementation work before we can claim broad language coverage:
+
+- **Structured types and interface blocks** – The keyword table does not intern `struct` or related declarations yet, so user-defined structs and uniform blocks cannot be parsed.
+- **Switch statements** – There is no token kind for `switch`, `case`, or `default`, leaving structured multi-branch control flow unsupported.
+- **Increment/decrement operators** – The token set lacks `++`/`--`, so post/pre increment expressions are rejected today.
+- **Boolean literals** – `true`/`false` are not registered as keywords, which prevents direct boolean literals in shaders.
+- **Preprocessor directives** – The lexer has no handling for `#` directives, so includes and defines are still out of scope.
+
+Documenting these gaps keeps the roadmap visible as we expand snippet coverage and the core transpiler functionality.


### PR DESCRIPTION
## Summary
- add compiler lifecycle helpers with a reusable `transpile` entry point
- add reusable shader snippets for core GLSL 450 features and run them from `main`
- extend unit tests to cover array indexing/swizzles and record unsupported language gaps

## Testing
- cc -std=c11 -Wall -Wextra -pedantic main.c -o transpiler_test

------
https://chatgpt.com/codex/tasks/task_e_68e16b8d9ca083238fe0a6aa4a1f83f9