### PR TITLE
Fix warnings when building with strict flags

### DIFF
--- a/ckit.h
+++ b/ckit.h
@@ -194,6 +194,7 @@ const char* str_intern_range(const char* start, const char* end);
 #include <stddef.h>
 
 #ifndef _MSC_VER
+#	include <strings.h>
 #	ifndef _stricmp
 #		define _stricmp strcasecmp
 #	endif
@@ -202,10 +203,10 @@ const char* str_intern_range(const char* start, const char* end);
 void* agrow(const void* a, int new_size, size_t element_size)
 {
 	ACANARY(a);
-	assert(acap(a) <= (SIZE_MAX - 1)/2);
+	assert((size_t)acap(a) <= (SIZE_MAX - 1) / 2);
 	int new_capacity = ((2 * acap(a)) > ((new_size > 16) ? new_size : 16) ? (2 * acap(a)) : ((new_size > 16) ? new_size : 16));
 	assert(new_size <= new_capacity);
-	assert(new_capacity <= (SIZE_MAX - sizeof(ArrayHeader)) / element_size);
+	assert((size_t)new_capacity <= (SIZE_MAX - sizeof(ArrayHeader)) / element_size);
 	size_t total_size = sizeof(ArrayHeader) + new_capacity * element_size;
 	ArrayHeader* hdr;
 	if (a) {


### PR DESCRIPTION
## Summary
- include <strings.h> for strcasecmp when building on non-MSVC toolchains
- cast dynamic array capacity checks to size_t to avoid sign-compare warnings
- explicitly discard apop() results to silence unused-value warnings

## Testing
- cc -std=c11 -Wall -Wextra -Werror main.c -o transpiler
- ./transpiler


------
https://chatgpt.com/codex/tasks/task_e_68e179ec8e7c832386987682f9c3fcae