### PR TITLE
Add boolean literal support

### DIFF
--- a/lex_parse.c
+++ b/lex_parse.c
@@ -39,6 +39,8 @@ const char* kw_discard;
 const char* kw_for;
 const char* kw_while;
 const char* kw_do;
+const char* kw_true;
+const char* kw_false;
 
 void init_keyword_interns()
 {
@@ -58,6 +60,8 @@ void init_keyword_interns()
 	kw_for = sintern("for");
 	kw_while = sintern("while");
 	kw_do = sintern("do");
+	kw_true = sintern("true");
+	kw_false = sintern("false");
 }
 
 SymbolTable g_symbol_table;
@@ -781,6 +785,13 @@ void expr_int()
 	next();
 }
 
+void expr_bool()
+{
+	IR_Cmd* inst = ir_emit(IR_PUSH_BOOL);
+	inst->arg0 = tok.int_val;
+	next();
+}
+
 void expr_float()
 {
 	IR_Cmd* inst = ir_emit(IR_PUSH_FLOAT);
@@ -1470,6 +1481,12 @@ void next()
 		{
 			tok.kind = TOK_DISCARD;
 			tok.lexpr = expr_error;
+		}
+		else if (tok.lexeme == kw_true || tok.lexeme == kw_false)
+		{
+			tok.kind = TOK_BOOL;
+			tok.lexpr = expr_bool;
+			tok.int_val = tok.lexeme == kw_true;
 		}
 		return;
 	}

--- a/main.c
+++ b/main.c
@@ -18,6 +18,7 @@ typedef enum Tok
 	TOK_IDENTIFIER,
 	TOK_INT,
 	TOK_FLOAT,
+	TOK_BOOL,
 
 	TOK_LPAREN,
 	TOK_RPAREN,
@@ -67,6 +68,7 @@ const char* tok_name[TOK_COUNT] = {
 	[TOK_IDENTIFIER] = "IDENT",
 	[TOK_INT] = "INT",
 	[TOK_FLOAT] = "FLOAT",
+	[TOK_BOOL] = "BOOL",
 
 	[TOK_LPAREN] = "(",
 	[TOK_RPAREN] = ")",
@@ -198,6 +200,7 @@ typedef enum IR_Op
 	IR_PUSH_INT,
 	IR_PUSH_IDENT,
 	IR_PUSH_FLOAT,
+	IR_PUSH_BOOL,
 	IR_UNARY,
 	IR_BINARY,
 	IR_CALL,
@@ -274,6 +277,7 @@ const char* ir_op_name[IR_OP_COUNT] = {
 	[IR_PUSH_INT] = "push_int",
 	[IR_PUSH_IDENT] = "push_ident",
 	[IR_PUSH_FLOAT] = "push_float",
+	[IR_PUSH_BOOL] = "push_bool",
 	[IR_UNARY] = "unary",
 	[IR_BINARY] = "binary",
 	[IR_CALL] = "call",
@@ -428,6 +432,7 @@ const char* snippet_array_indexing = STR(
 		uint uints[3];
 		uints[2] = 3u;
 		bool flags[2];
+		flags[0] = false;
 		flags[1] = ints[1] > 0;
 		vec4 vectors[2];
 		vec4 v = vectors[1];
@@ -437,8 +442,9 @@ const char* snippet_array_indexing = STR(
 		float element = column[2];
 		out_color = vec4(scalars[0], float(ints[1]), v.x, element);
 		bool flag = flags[1];
+		bool literal_true = true;
 		uint value = uints[2];
-		if (flag)
+		if (literal_true && flag)
 		{
 			out_color.xy += vec2(float(value));
 		}

--- a/testing.c
+++ b/testing.c
@@ -65,6 +65,9 @@ void dump_ir()
 		case IR_PUSH_FLOAT:
 			printf(" %g", inst->float_val);
 			break;
+		case IR_PUSH_BOOL:
+			printf(" %s", inst->arg0 ? "true" : "false");
+			break;
 		case IR_PUSH_IDENT:
 		case IR_MEMBER:
 		case IR_DECL_TYPE:
@@ -185,8 +188,13 @@ void unit_test()
 	int saw_bool_index = 0;
 	int saw_vec_index = 0;
 	int saw_mat_index = 0;
+	int saw_bool_literal = 0;
 	for (int i = 0; i < acount(g_ir); ++i)
 	{
+		if (g_ir[i].op == IR_PUSH_BOOL)
+		{
+			saw_bool_literal = 1;
+		}
 		if (g_ir[i].op != IR_INDEX)
 			continue;
 		saw_index = 1;
@@ -224,6 +232,7 @@ void unit_test()
 	assert(saw_int_index);
 	assert(saw_uint_index);
 	assert(saw_bool_index);
+	assert(saw_bool_literal);
 	assert(saw_vec_index);
 	assert(saw_mat_index);
 

--- a/type.c
+++ b/type.c
@@ -765,6 +765,10 @@ void type_check_ir()
 			inst->type = g_type_float;
 			apush(stack, inst->type);
 			break;
+		case IR_PUSH_BOOL:
+			inst->type = g_type_bool;
+			apush(stack, inst->type);
+			break;
 		case IR_PUSH_IDENT:
 		{
 			Type* type = NULL;


### PR DESCRIPTION
## Summary
- intern `true`/`false`, lex them as boolean literals, and emit a new IR opcode for boolean constants
- extend token/op enumerations, string tables, and IR dumping to report boolean literals
- push `g_type_bool` during type checking so boolean constants type-check correctly
- update the array_indexing shader snippet and unit test to exercise boolean literals

## Testing
- cc -std=c99 -Wall -Wextra main.c -o transpiler
- ./transpiler

------
https://chatgpt.com/codex/tasks/task_e_68e1a0e1d5d08323942462122d624f07