### PR TITLE
Improve ++/-- lexing macros and add coverage

### DIFF
--- a/lex_parse.c
+++ b/lex_parse.c
@@ -792,6 +792,9 @@ void expr_ident()
 {
 	IR_Cmd* inst = ir_emit(IR_PUSH_IDENT);
 	inst->str0 = sintern_range(tok.lexeme, tok.lexeme + tok.len);
+	Symbol* sym = symbol_table_find(inst->str0);
+	if (sym && (sym->kind == SYM_VAR || sym->kind == SYM_PARAM))
+		inst->is_lvalue = 1;
 	next();
 }
 
@@ -856,9 +859,12 @@ void expr_call()
 
 void expr_index()
 {
+	int base_idx = acount(g_ir) - 1;
 	expr(); // parse index expr
 	expect(TOK_RBRACK);
-	ir_emit(IR_INDEX);
+	IR_Cmd* inst = ir_emit(IR_INDEX);
+	if (base_idx >= 0 && base_idx < acount(g_ir))
+		inst->is_lvalue = g_ir[base_idx].is_lvalue;
 }
 
 int swizzle_set_from_char(char c)
@@ -924,8 +930,31 @@ int swizzle_is_valid(const char* name, int len, int* out_mask)
 	return 1;
 }
 
+int swizzle_is_assignable(const char* name, int len)
+{
+	if (len <= 1)
+		return 1;
+	int set = swizzle_set_from_char(name[0]);
+	if (set < 0)
+		return 0;
+	int seen = 0;
+	for (int i = 0; i < len; ++i)
+	{
+		int comp = swizzle_component_index(set, name[i]);
+		if (comp < 0)
+			return 0;
+		int bit = 1 << comp;
+		if (seen & bit)
+			return 0;
+		seen |= bit;
+	}
+	return 1;
+}
+
 void expr_member()
 {
+	int base_idx = acount(g_ir) - 1;
+	int base_is_lvalue = (base_idx >= 0 && base_idx < acount(g_ir)) ? g_ir[base_idx].is_lvalue : 0;
 	if (tok.kind != TOK_IDENTIFIER)
 		parse_error("expected identifier after '.'");
 	const char* name = tok.lexeme;
@@ -936,11 +965,13 @@ void expr_member()
 		inst->str0 = sintern_range(name, name + tok.len);
 		inst->arg0 = tok.len;
 		inst->arg1 = mask;
+		inst->is_lvalue = base_is_lvalue && swizzle_is_assignable(name, tok.len);
 	}
 	else
 	{
 		IR_Cmd* inst = ir_emit(IR_MEMBER);
 		inst->str0 = sintern_range(name, name + tok.len);
+		inst->is_lvalue = base_is_lvalue;
 	}
 	next();
 }
@@ -967,6 +998,56 @@ void expr_unary_common(Tok op)
 	expr_binary(PREC_UNARY - 1);
 	IR_Cmd* inst = ir_emit(IR_UNARY);
 	inst->tok = op;
+}
+
+int ir_expect_lvalue_index(const char* error_msg)
+{
+	if (!acount(g_ir))
+		parse_error(error_msg);
+	int idx = acount(g_ir) - 1;
+	if (!g_ir[idx].is_lvalue)
+		parse_error(error_msg);
+	return idx;
+}
+
+void expr_pre_inc()
+{
+	next();
+	expr_binary(PREC_UNARY - 1);
+	int idx = ir_expect_lvalue_index("operand of ++ must be an l-value");
+	IR_Cmd* inst = ir_emit(IR_UNARY);
+	inst->tok = TOK_PLUS_PLUS;
+	inst->arg0 = idx;
+	inst->arg1 = 0;
+}
+
+void expr_post_inc()
+{
+	int idx = ir_expect_lvalue_index("operand of ++ must be an l-value");
+	IR_Cmd* inst = ir_emit(IR_UNARY);
+	inst->tok = TOK_PLUS_PLUS;
+	inst->arg0 = idx;
+	inst->arg1 = 1;
+}
+
+void expr_pre_dec()
+{
+	next();
+	expr_binary(PREC_UNARY - 1);
+	int idx = ir_expect_lvalue_index("operand of -- must be an l-value");
+	IR_Cmd* inst = ir_emit(IR_UNARY);
+	inst->tok = TOK_MINUS_MINUS;
+	inst->arg0 = idx;
+	inst->arg1 = 0;
+}
+
+void expr_post_dec()
+{
+	int idx = ir_expect_lvalue_index("operand of -- must be an l-value");
+	IR_Cmd* inst = ir_emit(IR_UNARY);
+	inst->tok = TOK_MINUS_MINUS;
+	inst->arg0 = idx;
+	inst->arg1 = 1;
 }
 
 // Compact lex-parse technique learned from Per Vognsen
@@ -1285,6 +1366,51 @@ void parse()
 		} \
 		break;
 
+#define TOK_EXPR_OPTION(ch1, tok1, prec1, lexpr1, rexpr1, ch2, tok2, prec2, lexpr2, rexpr2) \
+	case ch1: \
+		next_ch(); \
+		if (match_ch(ch2)) \
+		{ \
+			tok.kind = TOK_##tok2; \
+			tok.prec = PREC_##prec2; \
+			tok.lexpr = expr_##lexpr2; \
+			tok.rexpr = expr_##rexpr2; \
+		} \
+		else \
+		{ \
+			tok.kind = TOK_##tok1; \
+			tok.prec = PREC_##prec1; \
+			tok.lexpr = expr_##lexpr1; \
+			tok.rexpr = expr_##rexpr1; \
+		} \
+		break;
+
+#define TOK_EXPR_OPTION2(ch1, tok1, prec1, lexpr1, rexpr1, ch2, tok2, prec2, lexpr2, rexpr2, ch3, tok3, prec3, lexpr3, rexpr3) \
+	case ch1: \
+		next_ch(); \
+		if (match_ch(ch2)) \
+		{ \
+			tok.kind = TOK_##tok2; \
+			tok.prec = PREC_##prec2; \
+			tok.lexpr = expr_##lexpr2; \
+			tok.rexpr = expr_##rexpr2; \
+		} \
+		else if (match_ch(ch3)) \
+		{ \
+			tok.kind = TOK_##tok3; \
+			tok.prec = PREC_##prec3; \
+			tok.lexpr = expr_##lexpr3; \
+			tok.rexpr = expr_##rexpr3; \
+		} \
+		else \
+		{ \
+			tok.kind = TOK_##tok1; \
+			tok.prec = PREC_##prec1; \
+			tok.lexpr = expr_##lexpr1; \
+			tok.rexpr = expr_##rexpr1; \
+		} \
+		break;
+
 void lex_number()
 {
 	const char* start = at - 1;
@@ -1389,8 +1515,8 @@ void next()
 
 		// prefix + binary-ish
 		TOK_EXPR('~', TILDE, UNARY, bnot, error)
-		TOK_EXPR_EXPR('+', PLUS, ADD, pos, add, '=', PLUS_ASSIGN, ASSIGN, error, plus_assign)
-		TOK_EXPR('-', MINUS, ADD, neg, sub)
+		TOK_EXPR_OPTION2('+', PLUS, ADD, pos, add, '+', PLUS_PLUS, POSTFIX, pre_inc, post_inc, '=', PLUS_ASSIGN, ASSIGN, error, plus_assign)
+		TOK_EXPR_OPTION('-', MINUS, ADD, neg, sub, '-', MINUS_MINUS, POSTFIX, pre_dec, post_dec)
 		TOK_EXPR('*', STAR, MUL, error, mul)
 		TOK_EXPR('/', SLASH, MUL, error, div)
 		TOK_EXPR('%', PERCENT, MUL, error, mod)

--- a/main.c
+++ b/main.c
@@ -46,6 +46,8 @@ typedef enum Tok
 	TOK_STAR,
 	TOK_SLASH,
 	TOK_PERCENT,
+	TOK_PLUS_PLUS,
+	TOK_MINUS_MINUS,
 	TOK_NOT,
 	TOK_TILDE,
 	TOK_LT,
@@ -95,6 +97,9 @@ const char* tok_name[TOK_COUNT] = {
 	[TOK_STAR] = "*",
 	[TOK_SLASH] = "/",
 	[TOK_PERCENT] = "%",
+
+	[TOK_PLUS_PLUS] = "++",
+	[TOK_MINUS_MINUS] = "--",
 
 	[TOK_NOT] = "!",
 	[TOK_TILDE] = "~",
@@ -360,6 +365,7 @@ typedef struct IR_Cmd
 	int layout_set;
 	int layout_binding;
 	int layout_location;
+	int is_lvalue;
 } IR_Cmd;
 
 // The global intermediate representation tape.
@@ -383,6 +389,7 @@ Type* type_system_get(const char* name);
 void type_system_free();
 void type_system_init_builtins();
 void type_system_init_builtins();
+Type* type_check_unary(const IR_Cmd* inst, Type* operand);
 void type_check_ir();
 void dump_ir();
 void dump_symbols();
@@ -403,10 +410,19 @@ const char* snippet_control_flow = STR(
 	layout(location = 0) out vec4 out_color;
 	void main() {
 		float accum = 0.0;
-		for (int i = 0; i < 4; i = i + 1)
+		int counter = 0;
+		accum += float(counter++);
+		accum += float(++counter);
+		vec2 adjustments = vec2(0.25, 0.25);
+		adjustments++;
+		--adjustments;
+		accum += adjustments.x;
+		for (int i = 0; i < 4; ++i)
 		{
 			accum += float(i) * 0.25;
 		}
+		counter--;
+		--counter;
 		if (accum > 0.5)
 		{
 			out_color = vec4(accum, 1.0 - accum, accum * 0.5, 1.0);

--- a/testing.c
+++ b/testing.c
@@ -143,7 +143,7 @@ void unit_test()
 	const char* custom_name = sintern("test_struct");
 	Type* declared_type = type_system_add_internal(custom_name, custom_type);
 	assert(declared_type == type_system_get(custom_name));
-	type_system_free(&ts);
+	type_system_free();
 
 	// Confirm symbol table scope chaining, storage flags, and layout metadata handling.
 	symbol_table_init();
@@ -154,7 +154,7 @@ void unit_test()
 	assert(value_sym && value_sym->name == value_name);
 	symbol_add_storage(value_sym, SYM_STORAGE_IN);
 	assert(symbol_has_storage(value_sym, SYM_STORAGE_IN));
-	symbol_table_enter_scope(&st);
+	symbol_table_enter_scope();
 	Type float_type_local = (Type){ 0 };
 	float_type_local.tag = T_FLOAT;
 	const char* inner_name = sintern("inner_value");
@@ -162,10 +162,10 @@ void unit_test()
 	symbol_set_layout(inner_sym, SYM_LAYOUT_LOCATION, 3);
 	assert(symbol_get_layout(inner_sym, SYM_LAYOUT_LOCATION) == 3);
 	assert(symbol_table_find(inner_name) == inner_sym);
-	symbol_table_leave_scope(&st);
+	symbol_table_leave_scope();
 	assert(symbol_table_find(inner_name) == NULL);
 	assert(symbol_table_find(value_name) == value_sym);
-	symbol_table_free(&st);
+	symbol_table_free();
 
 	// Check that IR emission produces entries with the requested opcode.
 	IR_Cmd* saved_ir = g_ir;
@@ -242,6 +242,61 @@ void unit_test()
 	assert(saw_swizzle[2]);
 	assert(saw_swizzle[3]);
 	assert(saw_swizzle[4]);
+
+	compiler_setup(snippet_control_flow);
+	int saw_pre_inc = 0;
+	int saw_post_inc = 0;
+	int saw_pre_dec = 0;
+	int saw_post_dec = 0;
+	int saw_pre_inc_lvalue = 0;
+	int saw_post_inc_lvalue = 0;
+	int saw_pre_dec_lvalue = 0;
+	int saw_post_dec_lvalue = 0;
+	for (int i = 0; i < acount(g_ir); ++i)
+	{
+		IR_Cmd* inst = &g_ir[i];
+		if (inst->op != IR_UNARY)
+			continue;
+		if (inst->tok == TOK_PLUS_PLUS)
+		{
+			if (inst->arg1 == 0)
+			{
+				saw_pre_inc = 1;
+				if (inst->arg0 >= 0 && inst->arg0 < acount(g_ir))
+					saw_pre_inc_lvalue = g_ir[inst->arg0].is_lvalue;
+			}
+			else if (inst->arg1 == 1)
+			{
+				saw_post_inc = 1;
+				if (inst->arg0 >= 0 && inst->arg0 < acount(g_ir))
+					saw_post_inc_lvalue = g_ir[inst->arg0].is_lvalue;
+			}
+		}
+		else if (inst->tok == TOK_MINUS_MINUS)
+		{
+			if (inst->arg1 == 0)
+			{
+				saw_pre_dec = 1;
+				if (inst->arg0 >= 0 && inst->arg0 < acount(g_ir))
+					saw_pre_dec_lvalue = g_ir[inst->arg0].is_lvalue;
+			}
+			else if (inst->arg1 == 1)
+			{
+				saw_post_dec = 1;
+				if (inst->arg0 >= 0 && inst->arg0 < acount(g_ir))
+					saw_post_dec_lvalue = g_ir[inst->arg0].is_lvalue;
+			}
+		}
+	}
+	compiler_teardown();
+	assert(saw_pre_inc);
+	assert(saw_post_inc);
+	assert(saw_pre_dec);
+	assert(saw_post_dec);
+	assert(saw_pre_inc_lvalue);
+	assert(saw_post_inc_lvalue);
+	assert(saw_pre_dec_lvalue);
+	assert(saw_post_dec_lvalue);
 
 	compiler_setup(snippet_function_calls);
 	assert(acount(g_ir) > 0);

--- a/type.c
+++ b/type.c
@@ -339,12 +339,34 @@ Type* type_bool_type(int components)
 
 void type_check_error(const char* fmt, ...);
 
-Type* type_check_unary(Tok tok, Type* operand)
+Type* type_check_unary(const IR_Cmd* inst, Type* operand)
 {
-	if (!operand)
-		return NULL;
+	if (!inst)
+		return operand;
+	Tok tok = inst->tok;
 	switch (tok)
 	{
+	case TOK_PLUS_PLUS:
+	case TOK_MINUS_MINUS:
+	{
+		if (!operand)
+			return NULL;
+		int idx = inst->arg0;
+		if (idx < 0 || idx >= acount(g_ir) || !g_ir[idx].is_lvalue)
+		{
+			type_check_error("operator %s requires l-value operand", tok_name[tok]);
+		}
+		if (!type_is_scalar(operand) && !type_is_vector(operand))
+		{
+			type_check_error("operator %s requires scalar or vector operand, got %s", tok_name[tok], type_display(operand));
+		}
+		TypeTag base = type_base_type(operand);
+		if (!type_base_is_numeric(base))
+		{
+			type_check_error("operator %s requires integer or float operand, got %s", tok_name[tok], type_display(operand));
+		}
+		return operand;
+	}
 	case TOK_MINUS:
 	case TOK_PLUS:
 		if (!type_is_numeric(operand) && !type_is_matrix(operand))
@@ -799,7 +821,7 @@ void type_check_ir()
 		case IR_UNARY:
 		{
 			Type* operand = type_stack_pop(stack, "unary expression");
-			Type* result = type_check_unary(inst->tok, operand);
+			Type* result = type_check_unary(inst, operand);
 			if (!result)
 				result = operand;
 			inst->type = result;


### PR DESCRIPTION
## Summary
- introduce helper macros so the Pratt lexer handles +/++/+= and -/-- combinations without bespoke cases
- switch increment/decrement tokenization to the new macros to ensure prefix and postfix forms are wired consistently
- extend the unit tests to validate ++/-- IR emission and fix the harness to call the symbol/type helpers with the correct signatures

## Testing
- cc -std=c99 main.c -o transpiler
- ./transpiler > output.txt

------
https://chatgpt.com/codex/tasks/task_e_68e1a0e630dc832391d797e60bd98ad5