### PR TITLE
Document std140-only uniform layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ Codename for this project is "transpiler".
 
 Transpiler will simply be like a "front end" compiler, except it will have scoped down input form expectations. Only basic glsl 450 shaders with vertex/fragment shaders are allowed. A single uniform buffer, input textures, control constructs like if/else/while/ternary are supported. Input types are simple and expected types such as int, vec2..4, matrix4. Builtin functions like dot, clamp, frac, etc. are all supported. However complex other types of shaders like geometry or tessselation shaders are just simply not supported, as we want to gracefully map back onto GLES3 shaders.
 
+Uniform buffer layouts must use `std140`. Other layouts such as `std430` or vendor-specific extensions are out of scope for this project and do not need to be supported.
+
 # Implementation
 
 We're using ckit.h to power our C fundamentals with dynamic array (such as apush, apop, etc.), and a Map such as map_add, map_get, etc. We also have `sintern` for string interning to be used by the transpiler.


### PR DESCRIPTION
## Summary
- clarify in the project guidelines that uniform buffers must use std140 layout
- note that other layouts like std430 or vendor extensions are out of scope

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e1b8c67df883239c210a3c9dee69e7