### PR TITLE
Add support for base-prefixed numeric literals

### DIFF
--- a/lex_parse.c
+++ b/lex_parse.c
@@ -1956,22 +1956,85 @@ void parse()
 		} \
 		break;
 
+static int digit_value_for_base(char c, int base)
+{
+	int value = -1;
+	if (c >= '0' && c <= '9')
+		value = c - '0';
+	else if (c >= 'a' && c <= 'f')
+		value = 10 + (c - 'a');
+	else if (c >= 'A' && c <= 'F')
+		value = 10 + (c - 'A');
+	return (value >= 0 && value < base) ? value : -1;
+}
+
 void lex_number()
 {
 	const char* start = at - 1;
-	char* endptr = NULL;
-	double val = strtod(start, &endptr);
-	const char* end = endptr;
-	const char* suffix = end;
+	const char* suffix = NULL;
+	const char* number_end = NULL;
 	int is_float = 0;
-	for (const char* p = start; p < end; ++p)
+	double float_val = 0.0;
+	unsigned long long int_val = 0;
+	int base = 10;
+	int use_manual_base = 0;
+	const char* digits_start = start;
+	if (*start == '0')
 	{
-		if (*p == '.' || *p == 'e' || *p == 'E')
+		char next = start[1];
+		if (next == 'x' || next == 'X')
 		{
-			is_float = 1;
-			break;
+			base = 16;
+			use_manual_base = 1;
+			digits_start = start + 2;
+		}
+		else if (next == 'b' || next == 'B')
+		{
+			base = 2;
+			use_manual_base = 1;
+			digits_start = start + 2;
+		}
+		else if (next && next != '.' && next != 'e' && next != 'E')
+		{
+			base = 8;
+			use_manual_base = 1;
+			digits_start = start + 1;
 		}
 	}
+	if (use_manual_base)
+	{
+		const char* p = digits_start;
+		while (1)
+		{
+			int digit = digit_value_for_base(*p, base);
+			if (digit < 0)
+				break;
+			int_val = int_val * (unsigned)base + (unsigned)digit;
+			++p;
+		}
+		number_end = p;
+		float_val = (double)int_val;
+		if (base == 8 && digits_start == start + 1 && number_end == digits_start)
+		{
+			// Account for a standalone zero literal.
+			number_end = digits_start;
+		}
+	}
+	else
+	{
+		char* endptr = NULL;
+		float_val = strtod(start, &endptr);
+		number_end = endptr;
+		for (const char* p = start; p < number_end; ++p)
+		{
+			if (*p == '.' || *p == 'e' || *p == 'E')
+			{
+				is_float = 1;
+				break;
+			}
+		}
+	}
+	suffix = number_end;
 	if (*suffix == 'f' || *suffix == 'F')
 	{
 		is_float = 1;
@@ -1997,18 +2060,25 @@ void lex_number()
 	{
 		tok.kind = TOK_FLOAT;
 		tok.lexpr = expr_float;
-		tok.float_val = val;
+		tok.float_val = float_val;
 	}
 	else
 	{
 		tok.kind = TOK_INT;
 		tok.lexpr = expr_int;
-		tok.int_val = 0;
-		for (const char* p = start; p < end; ++p)
+		if (use_manual_base)
 		{
-			if (*p >= '0' && *p <= '9')
+			tok.int_val = (int)int_val;
+		}
+		else
+		{
+			tok.int_val = 0;
+			for (const char* p = start; p < number_end; ++p)
 			{
-				tok.int_val = tok.int_val * 10 + (*p - '0');
+				if (*p >= '0' && *p <= '9')
+				{
+					tok.int_val = tok.int_val * 10 + (*p - '0');
+				}
 			}
 		}
 	}

--- a/main.c
+++ b/main.c
@@ -704,6 +704,15 @@ const char* snippet_bitwise = STR(
 			out_bits = values + ivec2(mask, mix + shifted);
 		});
 
+const char* snippet_numeric_literals = STR(
+		layout(location = 0) out ivec3 out_values;
+		void main() {
+			int hex_val = 0x1f;
+			int bin_val = 0b1010;
+			int oct_val = 075;
+			out_values = ivec3(hex_val, bin_val, oct_val);
+		});
+
 const char* snippet_switch_stmt = STR(
 		layout(location = 0) in int in_mode;
 		layout(location = 0) out vec4 out_color;
@@ -785,6 +794,7 @@ int main()
 		{ "matrix_ops", snippet_matrix_ops },
 		{ "looping", snippet_looping },
 		{ "bitwise", snippet_bitwise },
+		{ "numeric_literals", snippet_numeric_literals },
 		{ "discard", snippet_discard },
 		{ "switch", snippet_switch_stmt },
 		{ "builtin_funcs", snippet_builtin_funcs },

--- a/testing.c
+++ b/testing.c
@@ -603,6 +603,36 @@ DEFINE_TEST(test_bitwise_operations)
 	assert(saw_shr_assign);
 }
 
+DEFINE_TEST(test_numeric_literal_bases)
+{
+	compiler_setup(snippet_numeric_literals);
+	int saw_hex = 0;
+	int saw_bin = 0;
+	int saw_oct = 0;
+	for (int i = 0; i < acount(g_ir); ++i)
+	{
+		IR_Cmd* inst = &g_ir[i];
+		if (inst->op != IR_PUSH_INT)
+			continue;
+		if (inst->arg0 == 31)
+		{
+			saw_hex = 1;
+		}
+		else if (inst->arg0 == 10)
+		{
+			saw_bin = 1;
+		}
+		else if (inst->arg0 == 61)
+		{
+			saw_oct = 1;
+		}
+	}
+	compiler_teardown();
+	assert(saw_hex);
+	assert(saw_bin);
+	assert(saw_oct);
+}
+
 DEFINE_TEST(test_discard_instruction)
 {
 	compiler_setup(snippet_discard);
@@ -762,6 +792,7 @@ void unit_test()
 		TEST_ENTRY(test_matrix_operations_ir),
 		TEST_ENTRY(test_looping_constructs),
 		TEST_ENTRY(test_bitwise_operations),
+		TEST_ENTRY(test_numeric_literal_bases),
 		TEST_ENTRY(test_discard_instruction),
 		TEST_ENTRY(test_struct_block_layout),
 		TEST_ENTRY(test_switch_statement_cases),


### PR DESCRIPTION
## Summary
- extend the lexer to parse binary, octal, and hexadecimal prefixes while preserving suffix handling
- add a shader snippet that exercises prefixed integer literals for manual inspection
- add a unit test that confirms IR emission for the new literal forms and register it with the test suite

## Testing
- cc -std=c11 -Wall -Wextra -pedantic main.c -o transpiler
- ./transpiler

------
https://chatgpt.com/codex/tasks/task_e_68e1b81f97f4832383e15b6bab2517a4