### PR TITLE
Add struct constructor validation and tests

### DIFF
--- a/main.c
+++ b/main.c
@@ -223,6 +223,8 @@ void type_struct_member_set_layout(StructMember* member, unsigned layout_flags, 
 void type_struct_member_mark_array(StructMember* member, Type* element_type, int size, int unsized);
 void type_struct_set_layout_identifiers(Type* type, const char** identifiers, int count);
 StructMember* type_struct_find_member(Type* type, const char* name);
+int type_struct_member_count(Type* type);
+StructMember* type_struct_member_at(Type* type, int index);
 
 typedef enum BuiltinFuncKind
 {
@@ -792,6 +794,25 @@ const char* snippet_resource_types = STR(
 			out_color = vec4(base.rgb + volume.rgb, depth);
 		});
 
+const char* snippet_struct_constructor = STR(
+		struct Inner {
+			vec2 coords[2];
+		};
+		struct Outer {
+			float weight;
+			Inner segments[2];
+			float thresholds[4];
+		};
+		layout(location = 0) out vec4 out_color;
+		void main() {
+			Inner first = Inner(vec2(0.0, 1.0), vec2(2.0, 3.0));
+			Outer combo = Outer(1.0,
+				Inner(vec2(0.5, 0.5), vec2(0.75, 0.25)),
+				Inner(vec2(0.25, 0.75), vec2(0.5, 0.5)),
+				0.0, 1.0, 2.0, 3.0);
+			out_color = vec4(combo.segments[0].coords[1], combo.thresholds[3], combo.weight);
+		});
+
 // Directly include all of our source for a unity build.
 #include "lex_parse.c"
 #include "type.c"
@@ -832,6 +853,7 @@ int main()
 		{ "builtin_funcs", snippet_builtin_funcs },
 		{ "resource_types", snippet_resource_types },
 		{ "struct_block", snippet_struct_block },
+		{ "struct_constructor", snippet_struct_constructor },
 		{ "preprocessor_passthrough", snippet_preprocessor_passthrough },
 	};
 

--- a/testing.c
+++ b/testing.c
@@ -825,6 +825,30 @@ DEFINE_TEST(test_struct_block_layout)
 	assert(saw_block_member_array);
 }
 
+DEFINE_TEST(test_struct_constructor_ir)
+{
+	const char* inner_name = sintern("Inner");
+	const char* outer_name = sintern("Outer");
+	compiler_setup(snippet_struct_constructor);
+	int saw_inner_ctor = 0;
+	int saw_outer_ctor = 0;
+	for (int i = 0; i < acount(g_ir); ++i)
+	{
+		IR_Cmd* inst = &g_ir[i];
+		if (inst->op != IR_CONSTRUCT)
+			continue;
+		if (!inst->type || inst->type->tag != T_STRUCT)
+			continue;
+		if (inst->str0 == inner_name && inst->arg0 == 2)
+			saw_inner_ctor = 1;
+		if (inst->str0 == outer_name && inst->arg0 == 7)
+			saw_outer_ctor = 1;
+	}
+	compiler_teardown();
+	assert(saw_inner_ctor);
+	assert(saw_outer_ctor);
+}
+
 DEFINE_TEST(test_switch_statement_cases)
 {
 	compiler_setup(snippet_switch_stmt);
@@ -947,6 +971,7 @@ void unit_test()
 		TEST_ENTRY(test_numeric_literal_bases),
 		TEST_ENTRY(test_discard_instruction),
 		TEST_ENTRY(test_struct_block_layout),
+		TEST_ENTRY(test_struct_constructor_ir),
 		TEST_ENTRY(test_switch_statement_cases),
 		TEST_ENTRY(test_builtin_function_calls),
 		TEST_ENTRY(test_preprocessor_passthrough),


### PR DESCRIPTION
## Summary
- expose struct member accessors so constructor validation can iterate declared fields
- enhance constructor checking to recursively validate struct and array arguments and handle whole-struct operands
- add a GLSL snippet and regression test to cover struct constructor IR generation

## Testing
- ./transpiler > /tmp/transpiler_output.txt

------
https://chatgpt.com/codex/tasks/task_e_68e1d39bad1c8323a5cec0ac8eb267e9