### PR TITLE
Handle unsigned numeric literal parsing

### DIFF
--- a/lex_parse.c
+++ b/lex_parse.c
@@ -404,6 +404,7 @@ typedef struct Token
 	double float_val;
 	const char* lexeme;
 	int len;
+	int is_unsigned;
 } Token;
 
 Token tok;
@@ -1188,6 +1189,7 @@ void expr_int()
 {
 	IR_Cmd* inst = ir_emit(IR_PUSH_INT);
 	inst->arg0 = tok.int_val;
+	inst->is_unsigned_literal = tok.is_unsigned;
 	next();
 }
 
@@ -2048,6 +2050,7 @@ void lex_number()
 	int base = 10;
 	int use_manual_base = 0;
 	const char* digits_start = start;
+	int has_unsigned_suffix = 0;
 	if (*start == '0')
 	{
 		char next = start[1];
@@ -2118,9 +2121,14 @@ void lex_number()
 	{
 		while (*suffix == 'u' || *suffix == 'U' || *suffix == 'l' || *suffix == 'L')
 		{
+			if (*suffix == 'u' || *suffix == 'U')
+			{
+				has_unsigned_suffix = 1;
+			}
 			++suffix;
 		}
 	}
+	tok.is_unsigned = !is_float && has_unsigned_suffix;
 	tok.lexeme = start;
 	tok.len = (int)(suffix - start);
 	tok.prec = 0;
@@ -2173,6 +2181,7 @@ void next()
 	tok.float_val = 0.0;
 	tok.lexeme = at - 1;
 	tok.len = 0;
+	tok.is_unsigned = 0;
 
 	skip_ws_comments();
 
@@ -2346,6 +2355,7 @@ void reset_parser_state()
 	tok.float_val = 0.0;
 	tok.lexeme = NULL;
 	tok.len = 0;
+	tok.is_unsigned = 0;
 }
 
 void compiler_teardown()

--- a/main.c
+++ b/main.c
@@ -521,6 +521,7 @@ typedef struct IR_Cmd
 	int layout_set;
 	int layout_binding;
 	int layout_location;
+	int is_unsigned_literal;
 	int is_lvalue;
 } IR_Cmd;
 
@@ -725,11 +726,17 @@ const char* snippet_bitwise = STR(
 
 const char* snippet_numeric_literals = STR(
 		layout(location = 0) out ivec3 out_values;
+		layout(location = 1) out uvec3 out_uvalues;
 		void main() {
 			int hex_val = 0x1f;
 			int bin_val = 0b1010;
 			int oct_val = 075;
+			uint uhex_val = 0x1fu;
+			uint ubin_val = 0b1010u;
+			uint uoct_val = 075u;
+			uint udec_val = 42u;
 			out_values = ivec3(hex_val, bin_val, oct_val);
+			out_uvalues = uvec3(uhex_val, ubin_val, uoct_val);
 		});
 
 const char* snippet_switch_stmt = STR(

--- a/testing.c
+++ b/testing.c
@@ -75,6 +75,8 @@ void dump_ir()
 			break;
 		case IR_PUSH_INT:
 			printf(" %d", inst->arg0);
+			if (inst->is_unsigned_literal)
+				printf("u");
 			break;
 		case IR_PUSH_FLOAT:
 			printf(" %g", inst->float_val);
@@ -792,31 +794,61 @@ DEFINE_TEST(test_bitwise_operations)
 DEFINE_TEST(test_numeric_literal_bases)
 {
 	compiler_setup(snippet_numeric_literals);
-	int saw_hex = 0;
-	int saw_bin = 0;
-	int saw_oct = 0;
+	int saw_hex_int = 0;
+	int saw_bin_int = 0;
+	int saw_oct_int = 0;
+	int saw_hex_uint = 0;
+	int saw_bin_uint = 0;
+	int saw_oct_uint = 0;
+	int saw_dec_uint = 0;
 	for (int i = 0; i < acount(g_ir); ++i)
 	{
 		IR_Cmd* inst = &g_ir[i];
 		if (inst->op != IR_PUSH_INT)
 			continue;
-		if (inst->arg0 == 31)
+		if (inst->is_unsigned_literal)
 		{
-			saw_hex = 1;
+			if (inst->arg0 == 31)
+			{
+				saw_hex_uint = inst->type == g_type_uint;
+			}
+			else if (inst->arg0 == 10)
+			{
+				saw_bin_uint = inst->type == g_type_uint;
+			}
+			else if (inst->arg0 == 61)
+			{
+				saw_oct_uint = inst->type == g_type_uint;
+			}
+			else if (inst->arg0 == 42)
+			{
+				saw_dec_uint = inst->type == g_type_uint;
+			}
 		}
-		else if (inst->arg0 == 10)
+		else
 		{
-			saw_bin = 1;
-		}
-		else if (inst->arg0 == 61)
-		{
-			saw_oct = 1;
+			if (inst->arg0 == 31)
+			{
+				saw_hex_int = inst->type == g_type_int;
+			}
+			else if (inst->arg0 == 10)
+			{
+				saw_bin_int = inst->type == g_type_int;
+			}
+			else if (inst->arg0 == 61)
+			{
+				saw_oct_int = inst->type == g_type_int;
+			}
 		}
 	}
 	compiler_teardown();
-	assert(saw_hex);
-	assert(saw_bin);
-	assert(saw_oct);
+	assert(saw_hex_int);
+	assert(saw_bin_int);
+	assert(saw_oct_int);
+	assert(saw_hex_uint);
+	assert(saw_bin_uint);
+	assert(saw_oct_uint);
+	assert(saw_dec_uint);
 }
 
 DEFINE_TEST(test_discard_instruction)

--- a/type.c
+++ b/type.c
@@ -1396,7 +1396,7 @@ void type_check_ir()
 		switch (inst->op)
 		{
 		case IR_PUSH_INT:
-			inst->type = g_type_int;
+			inst->type = inst->is_unsigned_literal ? g_type_uint : g_type_int;
 			apush(stack, inst->type);
 			inst->qualifier_flags = 0;
 			apush(qualifier_stack, 0);


### PR DESCRIPTION
## Summary
- detect unsigned literal suffixes during lexing and flag tokens accordingly
- propagate unsigned literal metadata through IR and type checking so constants become uints
- extend the numeric literal shader snippet and unit test coverage to exercise unsigned values across bases

## Testing
- gcc -std=c11 -Wall -Wextra -Werror main.c -o transpiler
- ./transpiler > output.log


------
https://chatgpt.com/codex/tasks/task_e_68e29a1190e483239fec5e47f9faa5a9