### PR TITLE
Document builtin type inference helpers with GLSL examples

### DIFF
--- a/lex_parse.c
+++ b/lex_parse.c
@@ -114,11 +114,15 @@ Symbol* symbol_table_add(const char* name, const char* type_name, Type* type, Sy
 void symbol_add_storage(Symbol* sym, unsigned flags);
 void symbol_add_qualifier(Symbol* sym, unsigned flags);
 
+// Create a fresh scope for blocks like function bodies or if-statements.
+// ...if (use_shadows) { vec3 atten = vec3(0.0); }
 void symbol_table_enter_scope()
 {
 	apush(st->scopes, (SymbolScope){ 0 });
 }
 
+// Discard the innermost scope once we leave a block.
+// ...}
 void symbol_table_leave_scope()
 {
 	int count = acount(st->scopes);
@@ -177,6 +181,8 @@ static uint64_t symbol_function_signature_hash(Type** params, int param_count)
 	return hash;
 }
 
+// Look up an overload that matches a call site like light(in_pos).
+// ...float intensity = light(v_uv);
 static Symbol* symbol_table_find_function_overload_at_depth(const char* name, Type** params, int param_count, int scope_depth)
 {
 	SymbolScopeEntry* entry = symbol_scope_entry_at_depth(scope_depth, name, 0);
@@ -191,6 +197,8 @@ static Symbol* symbol_table_find_function_overload_at_depth(const char* name, Ty
 	return &st->symbols[(int)mapped - 1];
 }
 
+// Register a symbol for declarations such as float roughness; or void shade().
+// ...float roughness;
 static Symbol* symbol_table_add_internal(const char* name, const char* type_name, Type* type, SymbolKind kind, int scope_depth)
 {
 	if (!acount(st->scopes))
@@ -828,6 +836,8 @@ int is_type_token()
 	return 0;
 }
 
+// Consume layout(...) annotations that precede declarations.
+// ...layout(location = 0) out vec4 result;
 void parse_layout_block(TypeSpec* spec)
 {
 	next();
@@ -865,6 +875,8 @@ void parse_layout_block(TypeSpec* spec)
 	expect(TOK_RPAREN);
 }
 
+// Gather storage and qualifier keywords like uniform const.
+// ...uniform sampler2D u_image;
 void parse_type_qualifiers(TypeSpec* spec)
 {
 	while (tok.kind == TOK_IDENTIFIER)

--- a/type.c
+++ b/type.c
@@ -79,6 +79,8 @@ static StructInfo* type_struct_info_ensure(Type* type)
 	return info;
 }
 
+// Ensure we have a struct type ready for declarations like struct Material.
+// ...struct Material { vec4 albedo; };
 Type* type_system_declare_struct(const char* name)
 {
 	Type* existing = type_system_get(name);
@@ -102,7 +104,8 @@ Type* type_system_declare_struct(const char* name)
 	type_struct_clear(result);
 	return result;
 }
-
+// Reset cached members so repeated declarations start clean.
+// ...struct Material { vec4 albedo; };
 void type_struct_clear(Type* type)
 {
 	StructInfo* info = type_struct_info_ensure(type);
@@ -114,7 +117,8 @@ void type_struct_clear(Type* type)
 	if (info->layout_identifiers)
 		aclear(info->layout_identifiers);
 }
-
+// Append a member for struct fields encountered in user code.
+// ...struct Material { vec4 albedo; };
 StructMember* type_struct_add_member(Type* type, const char* name, Type* member_type)
 {
 	StructInfo* info = type_struct_info_ensure(type);
@@ -132,6 +136,8 @@ StructMember* type_struct_add_member(Type* type, const char* name, Type* member_
 	return &alast(info->members);
 }
 
+// Store layout qualifiers that come from layout(...) blocks on members.
+// ...layout(location = 0) vec4 color;
 void type_struct_member_set_layout(StructMember* member, unsigned layout_flags, int set, int binding, int location)
 {
 	if (!member)
@@ -141,7 +147,8 @@ void type_struct_member_set_layout(StructMember* member, unsigned layout_flags, 
 	member->layout_binding = binding;
 	member->layout_location = location;
 }
-
+// Update a member to reflect array declarations like float weights[4].
+// ...float weights[4];
 void type_struct_member_mark_array(StructMember* member, Type* element_type, int size, int unsized)
 {
 	if (!member)
@@ -602,6 +609,8 @@ static Type* builtin_result_vector(Type** args, int argc, int index, int compone
 	return type_get_vector(type_base_type(source), components);
 }
 
+// Pick the return type for sampling helpers like texture().
+// ...vec4 color = texture(u_image, v_uv);
 static Type* builtin_result_texture(Type** args, int argc)
 {
 	Type* sampler = (args && argc > 0) ? args[0] : NULL;
@@ -655,6 +664,8 @@ static int sampler_coord_components(const Type* sampler)
 	return components;
 }
 
+// Match the textureSize() return shape to the sampler argument.
+// ...ivec2 size = textureSize(u_image, 0);
 static Type* builtin_result_texture_size(Type** args, int argc)
 {
 	Type* sampler = (args && argc > 0) ? args[0] : NULL;
@@ -703,6 +714,8 @@ static Type* builtin_result_texture_size(Type** args, int argc)
 	return result ? result : type_get_scalar(T_INT);
 }
 
+// Check texelFetch() coordinates, lod/sample, and sampler compatibility.
+// ...ivec4 texel = texelFetch(u_image, ivec2(gl_FragCoord.xy), 0);
 static Type* builtin_result_texel_fetch(Type** args, int argc)
 {
 	Type* sampler = (args && argc > 0) ? args[0] : NULL;
@@ -781,6 +794,8 @@ static Type* builtin_result_texel_fetch(Type** args, int argc)
 	return builtin_result_texture(args, argc);
 }
 
+// Keep inverse() limited to square matrix inputs.
+// ...mat4 inv_model = inverse(model);
 static Type* builtin_result_inverse(Type** args, int argc)
 {
 	Type* mat = (args && argc > 0) ? args[0] : NULL;
@@ -796,6 +811,8 @@ static Type* builtin_result_inverse(Type** args, int argc)
 	return mat;
 }
 
+// Flip the rows and columns for transpose() return types.
+// ...mat3 normal_mat = transpose(inverse(mat3(model)));
 static Type* builtin_result_transpose(Type** args, int argc)
 {
 	Type* mat = (args && argc > 0) ? args[0] : NULL;
@@ -808,6 +825,8 @@ static Type* builtin_result_transpose(Type** args, int argc)
 	return result ? result : mat;
 }
 
+// Enforce matching shapes for relational helpers like lessThan().
+// ...bvec3 mask = lessThan(a.xyz, b.xyz);
 static Type* builtin_result_relational(Type** args, int argc, int allow_bool)
 {
 	Type* lhs = (args && argc > 0) ? args[0] : NULL;
@@ -843,6 +862,8 @@ static Type* builtin_result_relational(Type** args, int argc, int allow_bool)
 	return type_get_vector(T_BOOL, components);
 }
 
+// Collapse boolean vectors for any()/all() reductions.
+// ...bool is_visible = all(greaterThanEqual(alpha.rgb, vec3(0.0)));
 static Type* builtin_result_any_all(Type** args, int argc)
 {
 	Type* arg = (args && argc > 0) ? args[0] : NULL;
@@ -858,6 +879,8 @@ static Type* builtin_result_any_all(Type** args, int argc)
 
 
 
+// Route builtin calls to the helper that checks their arguments.
+// ...float lighting = dot(normal, light_dir);
 Type* type_infer_builtin_call(const Symbol* sym, Type** args, int argc)
 {
 	if (!sym)


### PR DESCRIPTION
## Summary
- adjust builtin type inference comments to follow plain-language guidance with inline usage snippets
- add documentation to struct helpers so their role in user-facing declarations is clear
- document parser scope management and qualifier parsing routines with shader examples

## Testing
- not run (comments only)

------
https://chatgpt.com/codex/tasks/task_e_68e2be1c8b808323bef951a3d51962dc