### PR TITLE
Clarify parser and builtin documentation

### DIFF
--- a/lex_parse.c
+++ b/lex_parse.c
@@ -967,6 +967,9 @@ void parse_type_qualifiers(TypeSpec* spec)
 	}
 }
 
+// Parse qualifiers and the core type that lead a declaration or parameter list.
+// ...layout(std140, binding = 0) uniform Globals { mat4 vp; } u_globals;
+// ...vec3 normal;
 TypeSpec parse_type_specifier()
 {
 	TypeSpec spec = (TypeSpec){ 0 };
@@ -1037,6 +1040,8 @@ TypeSpec parse_type_specifier()
 	return spec;
 }
 
+// Parse trailing brackets on struct members like weights[4].
+// ...struct Light { float weights[4]; };
 void parse_struct_member_array_suffix(StructMember* member)
 {
 	while (tok.kind == TOK_LBRACK)
@@ -1116,6 +1121,9 @@ void emit_struct_ir(Type* type, StructInfo* info)
 	ir_emit(IR_STRUCT_END);
 }
 
+// Emit IR for interface blocks so the backend sees each layout and field.
+// ...layout(set = 1, binding = 0)
+// ...uniform Globals { mat4 vp; } u_globals;
 void interface_block_decl(const TypeSpec* spec, const char* instance_name)
 {
 	if (!spec || !spec->type)

--- a/type.c
+++ b/type.c
@@ -252,6 +252,8 @@ static void append_cstr(dyna char** buffer, const char* str)
 		apush(*buffer, *it);
 }
 
+// Format a comma-separated argument list for diagnostics such as:
+// ...error: dot requires second argument to match first argument base type, got vec3, ivec3
 static const char* format_argument_type_list(Type** args, int count)
 {
 	static dyna char* buffer = NULL;
@@ -713,6 +715,8 @@ enum
 	BUILTIN_ARG_MATCH_SHAPE = 1 << 6,
 };
 
+// Validate a builtin invocation against per-argument rules before resolving it.
+// ...error: distance requires second argument to match first argument shape, got vec3 and vec2
 static int builtin_validate_args(const Symbol* sym, Type** args, int argc, const BuiltinArgConstraint* constraints, int constraint_count)
 {
 	int all_ok = 1;
@@ -860,6 +864,8 @@ static Type* builtin_result_derivative(const Symbol* sym, Type** args, int argc)
 	return builtin_result_same(args, argc, 0);
 }
 
+// Enforce numeric scalar/vector arguments so min/max style builtins report clear errors.
+// ...error: min requires numeric second argument, got mat2
 static int builtin_validate_numeric_scalar_vector(const Symbol* sym, const Type* arg, const char* role)
 {
 	const char* name = builtin_func_name(sym);
@@ -961,6 +967,8 @@ static Type* builtin_result_min_max(const Symbol* sym, Type** args, int argc)
 	return x;
 }
 
+// Validate clamp(x, min, max) and return the clamped value type.
+// ...vec3 lit = clamp(raw, vec3(0.0), vec3(1.0));
 static Type* builtin_result_clamp(const Symbol* sym, Type** args, int argc)
 {
 	Type* x = (argc > 0) ? args[0] : NULL;
@@ -1006,6 +1014,8 @@ static Type* builtin_result_clamp(const Symbol* sym, Type** args, int argc)
 	return x;
 }
 
+// Resolve abs/similar functions that mirror their argument type.
+// ...vec3 mag = abs(force);
 static Type* builtin_result_abs_like(const Symbol* sym, Type** args, int argc)
 {
 	Type* value = (argc > 0) ? args[0] : NULL;


### PR DESCRIPTION
## Summary
- refine parser comments to clarify how declarations and interface blocks are interpreted
- update builtin helper documentation to reference actual diagnostics and prune redundant notes

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68e2daee27e08323bf253e7c638b08df