### PR TITLE
Add SPINDLE_NO_TESTS opt-out for bundled tests

### DIFF
--- a/main.c
+++ b/main.c
@@ -26,6 +26,7 @@ void compile(ShaderStage stage, const char* source)
 
 int main()
 {
+#ifndef SPINDLE_NO_TESTS
 	unit_test();
 
 	typedef struct ShaderSnippet
@@ -68,6 +69,8 @@ int main()
 		compile(snippets[i].stage, snippets[i].source);
 		printf("\n");
 	}
+
+#endif
 
 	return 0;
 }

--- a/spindle.h
+++ b/spindle.h
@@ -7,6 +7,8 @@
 		#define SPINDLE_IMPLEMENTATION
 		#include "spindle.h"
 
+	Define SPINDLE_NO_TESTS before including spindle.h to omit snippets and unit tests.
+
 	Requires ckit.h for dynamic arrays, maps, and string interning.
 	Be sure to include ckit before spindle to provide those facilities.
 
@@ -39,7 +41,9 @@ void compiler_setup(const char* source);
 void compiler_teardown();
 void dump_ir();
 void dump_symbols();
+#ifndef SPINDLE_NO_TESTS
 void unit_test();
+#endif
 
 #ifdef __cplusplus
 }
@@ -6599,6 +6603,7 @@ void dump_symbols()
 	}
 }
 
+#ifndef SPINDLE_NO_TESTS
 typedef void (*TestFunc)(void);
 
 typedef struct TestCase
@@ -7800,5 +7805,7 @@ void unit_test()
 	};
 	run_tests(tests, (int)(sizeof(tests) / sizeof(tests[0])));
 }
+
+#endif /* SPINDLE_NO_TESTS */
 
 #endif /* SPINDLE_IMPLEMENTATION */


### PR DESCRIPTION
## Summary
- document the SPINDLE_NO_TESTS macro in spindle.h and guard the unit_test declaration
- wrap the snippet fixtures and unit test harness in SPINDLE_NO_TESTS so they can be excluded
- skip running unit tests and snippets from main when SPINDLE_NO_TESTS is defined

## Testing
- cc main.c -o spindle_demo
- cc -DSPINDLE_NO_TESTS main.c -o spindle_demo_notests

------
https://chatgpt.com/codex/tasks/task_e_68e319472b3083239188a698a0971290