### PR TITLE
Silence unused-value warnings around apop discards

### DIFF
--- a/spindle.h
+++ b/spindle.h
@@ -55,6 +55,14 @@ void unit_test();
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+#endif
+
 #ifndef CKIT_H
 #error "spindle.h requires ckit.h to be included before it."
 #endif
@@ -774,7 +782,7 @@ void symbol_table_leave_scope()
 	if (scope->entries)
 		afree(scope->entries);
 	map_free(scope->map);
-	(void)apop(st->scopes);
+	apop(st->scopes);
 }
 
 static SymbolScopeEntry* symbol_scope_entry(SymbolScope* scope, const char* name, int create)
@@ -5502,9 +5510,9 @@ void type_check_ir()
 			Type* operand = type_stack_pop(stack, "unary expression");
 			unsigned operand_qualifier = acount(qualifier_stack) ? apop(qualifier_stack) : 0;
 			if (acount(storage_stack))
-				(void)apop(storage_stack);
+				apop(storage_stack);
 			if (acount(symbol_stack))
-				(void)apop(symbol_stack);
+				apop(symbol_stack);
 			Type* result = type_check_unary(inst, operand);
 			if ((inst->tok == TOK_PLUS_PLUS || inst->tok == TOK_MINUS_MINUS) && (operand_qualifier & SYM_QUAL_CONST)) {
 				type_check_error("cannot modify const-qualified value");
@@ -5522,14 +5530,14 @@ void type_check_ir()
 		case IR_BINARY: {
 			Type* rhs = type_stack_pop(stack, "binary rhs");
 			if (acount(storage_stack))
-				(void)apop(storage_stack);
+				apop(storage_stack);
 			if (acount(symbol_stack))
-				(void)apop(symbol_stack);
+				apop(symbol_stack);
 			Type* lhs = type_stack_pop(stack, "binary lhs");
 			unsigned lhs_storage = acount(storage_stack) ? apop(storage_stack) : 0;
 			Symbol* lhs_symbol = acount(symbol_stack) ? apop(symbol_stack) : NULL;
 			if (acount(qualifier_stack))
-				(void)apop(qualifier_stack);
+				apop(qualifier_stack);
 			unsigned lhs_qualifier = acount(qualifier_stack) ? apop(qualifier_stack) : 0;
 			int is_assignment = 0;
 			switch (inst->tok) {
@@ -5577,11 +5585,11 @@ void type_check_ir()
 			for (int arg = 0; arg < inst->arg0; ++arg) {
 				Type* arg_type = type_stack_pop(stack, "call argument");
 				if (acount(qualifier_stack))
-					(void)apop(qualifier_stack);
+					apop(qualifier_stack);
 				if (acount(storage_stack))
-					(void)apop(storage_stack);
+					apop(storage_stack);
 				if (acount(symbol_stack))
-					(void)apop(symbol_stack);
+					apop(symbol_stack);
 				apush(args, arg_type);
 			}
 			int argc = acount(args);
@@ -5592,11 +5600,11 @@ void type_check_ir()
 			}
 			Type* callee = type_stack_pop(stack, "call target");
 			if (acount(qualifier_stack))
-				(void)apop(qualifier_stack);
+				apop(qualifier_stack);
 			if (acount(storage_stack))
-				(void)apop(storage_stack);
+				apop(storage_stack);
 			if (acount(symbol_stack))
-				(void)apop(symbol_stack);
+				apop(symbol_stack);
 			Type* result = callee;
 			Symbol* sym = NULL;
 			if (inst->str0) {
@@ -5647,11 +5655,11 @@ void type_check_ir()
 			for (int arg = 0; arg < inst->arg0; ++arg) {
 				Type* arg_type = type_stack_pop(stack, "constructor argument");
 				if (acount(qualifier_stack))
-					(void)apop(qualifier_stack);
+					apop(qualifier_stack);
 				if (acount(storage_stack))
-					(void)apop(storage_stack);
+					apop(storage_stack);
 				if (acount(symbol_stack))
-					(void)apop(symbol_stack);
+					apop(symbol_stack);
 				apush(args, arg_type);
 			}
 			int argc = acount(args);
@@ -5663,9 +5671,9 @@ void type_check_ir()
 			Type* target = type_stack_pop(stack, "constructor target");
 			Type* result = inst->type ? inst->type : target;
 			if (acount(storage_stack))
-				(void)apop(storage_stack);
+				apop(storage_stack);
 			if (acount(symbol_stack))
-				(void)apop(symbol_stack);
+				apop(symbol_stack);
 			inst->type = result;
 			if (result)
 				type_check_constructor(result, args, argc);
@@ -5680,11 +5688,11 @@ void type_check_ir()
 		case IR_INDEX: {
 			Type* index = type_stack_pop(stack, "index expression");
 			if (acount(qualifier_stack))
-				(void)apop(qualifier_stack);
+				apop(qualifier_stack);
 			if (acount(storage_stack))
-				(void)apop(storage_stack);
+				apop(storage_stack);
 			if (acount(symbol_stack))
-				(void)apop(symbol_stack);
+				apop(symbol_stack);
 			Type* base = type_stack_pop(stack, "index base");
 			unsigned base_qualifier = acount(qualifier_stack) ? apop(qualifier_stack) : 0;
 			unsigned base_storage = acount(storage_stack) ? apop(storage_stack) : 0;
@@ -5766,25 +5774,25 @@ void type_check_ir()
 		case IR_SELECT: {
 			Type* false_type = type_stack_pop(stack, "ternary false branch");
 			if (acount(qualifier_stack))
-				(void)apop(qualifier_stack);
+				apop(qualifier_stack);
 			if (acount(storage_stack))
-				(void)apop(storage_stack);
+				apop(storage_stack);
 			if (acount(symbol_stack))
-				(void)apop(symbol_stack);
+				apop(symbol_stack);
 			Type* true_type = type_stack_pop(stack, "ternary true branch");
 			if (acount(qualifier_stack))
-				(void)apop(qualifier_stack);
+				apop(qualifier_stack);
 			if (acount(storage_stack))
-				(void)apop(storage_stack);
+				apop(storage_stack);
 			if (acount(symbol_stack))
-				(void)apop(symbol_stack);
+				apop(symbol_stack);
 			Type* cond_type = type_stack_pop(stack, "ternary condition");
 			if (acount(qualifier_stack))
-				(void)apop(qualifier_stack);
+				apop(qualifier_stack);
 			if (acount(storage_stack))
-				(void)apop(storage_stack);
+				apop(storage_stack);
 			if (acount(symbol_stack))
-				(void)apop(symbol_stack);
+				apop(symbol_stack);
 			Type* result = type_select_result(cond_type, true_type, false_type);
 			if (!result)
 				result = true_type ? true_type : false_type;
@@ -5812,7 +5820,7 @@ void type_check_ir()
 			if (acount(stack) > 0) {
 				Type* value = type_stack_pop(stack, "initializer");
 				if (acount(qualifier_stack))
-					(void)apop(qualifier_stack);
+					apop(qualifier_stack);
 				if (current_decl_type && value && !type_can_assign(current_decl_type, value)) {
 					type_check_error("initializer type %s cannot initialize %s %s", type_display(value), current_decl_name ? current_decl_name : "value", type_display(current_decl_type));
 				}
@@ -5827,7 +5835,7 @@ void type_check_ir()
 			if (acount(stack) > 0) {
 				Type* size = type_stack_pop(stack, "array size");
 				if (acount(qualifier_stack))
-					(void)apop(qualifier_stack);
+					apop(qualifier_stack);
 				if (size && (!type_is_scalar(size) || !type_is_integer(size))) {
 					type_check_error("array size must be integer scalar, got %s", type_display(size));
 				}
@@ -5845,7 +5853,7 @@ void type_check_ir()
 		case IR_SWITCH_SELECTOR_END: {
 			Type* selector = type_stack_pop(stack, "switch selector");
 			if (acount(qualifier_stack))
-				(void)apop(qualifier_stack);
+				apop(qualifier_stack);
 			if (selector && (!type_is_scalar(selector) || !type_is_integer(selector))) {
 				type_check_error("switch selector must be integer scalar, got %s", type_display(selector));
 			}
@@ -5900,18 +5908,18 @@ void type_check_ir()
 				}
 			}
 			afree(ctx->cases);
-			(void)apop(switch_stack);
+			apop(switch_stack);
 			break;
 		}
 		case IR_STMT_EXPR:
 			if (acount(stack) > 0) {
 				type_stack_pop(stack, "expression result");
 				if (acount(qualifier_stack))
-					(void)apop(qualifier_stack);
+					apop(qualifier_stack);
 				if (acount(storage_stack))
-					(void)apop(storage_stack);
+					apop(storage_stack);
 				if (acount(symbol_stack))
-					(void)apop(symbol_stack);
+					apop(symbol_stack);
 			}
 			if (acount(stack) > 0)
 				aclear(stack);
@@ -5925,11 +5933,11 @@ void type_check_ir()
 		case IR_IF_THEN: {
 			Type* cond = type_stack_pop(stack, "if condition");
 			if (acount(qualifier_stack))
-				(void)apop(qualifier_stack);
+				apop(qualifier_stack);
 			if (acount(storage_stack))
-				(void)apop(storage_stack);
+				apop(storage_stack);
 			if (acount(symbol_stack))
-				(void)apop(symbol_stack);
+				apop(symbol_stack);
 			if (cond && (!type_is_bool_like(cond) || !type_is_scalar(cond))) {
 				type_check_error("if condition must be boolean scalar, got %s", type_display(cond));
 			}
@@ -5940,11 +5948,11 @@ void type_check_ir()
 			if (inst->arg0) {
 				Type* value = type_stack_pop(stack, "return value");
 				if (acount(qualifier_stack))
-					(void)apop(qualifier_stack);
+					apop(qualifier_stack);
 				if (acount(storage_stack))
-					(void)apop(storage_stack);
+					apop(storage_stack);
 				if (acount(symbol_stack))
-					(void)apop(symbol_stack);
+					apop(symbol_stack);
 				if (ret_type && ret_type != g_type_void && value && !type_can_assign(ret_type, value)) {
 					type_check_error("return type mismatch: expected %s got %s", type_display(ret_type), type_display(value));
 				}
@@ -5962,7 +5970,7 @@ void type_check_ir()
 		case IR_FUNC_PROTOTYPE_END:
 		case IR_FUNC_DEFINITION_END:
 			if (acount(func_stack) > 0)
-				(void)apop(func_stack);
+				apop(func_stack);
 			break;
 		default:
 			break;
@@ -7800,5 +7808,11 @@ void unit_test()
 	};
 	run_tests(tests, (int)(sizeof(tests) / sizeof(tests[0])));
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif /* SPINDLE_IMPLEMENTATION */


### PR DESCRIPTION
## Summary
- restore the value-returning `apop` macro and previous type stack helper usage
- suppress `-Wunused-value` within `spindle.h` so discarding pops no longer need `(void)` casts

## Testing
- cc -std=c11 -Wall -Wextra -pedantic main.c -o main
- ./main

------
https://chatgpt.com/codex/tasks/task_e_68e3170b6dec8323ad6b75546269c35f